### PR TITLE
Gogoanime: added other names

### DIFF
--- a/src/en/gogoanime/build.gradle
+++ b/src/en/gogoanime/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Gogoanime'
     pkgNameSuffix = 'en.gogoanime'
     extClass = '.GogoAnime'
-    extVersionCode = 15
+    extVersionCode = 16
     libVersion = '12'
 }
 

--- a/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
+++ b/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
@@ -183,6 +183,17 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         anime.genre = document.select("p.type:eq(5) a").joinToString("") { it.text() }
         anime.description = document.select("p.type:eq(4)").first().ownText()
         anime.status = parseStatus(document.select("p.type:eq(7) a").text())
+
+    // add alternative name to anime description
+        val altName = "Other name(s): "
+        document.select("p.type:eq(8)").firstOrNull()?.ownText()?.let {
+            if (it.isBlank().not()) {
+                anime.description = when {
+                anime.description.isNullOrBlank() -> altName + it
+                    else -> anime.description + "\n\n$altName" + it
+                }
+            }
+        }
         return anime
     }
 


### PR DESCRIPTION
Gogo animes are mostly written in its japanese titles. Adding other names to the description makes it visible when searching anime that is in library.