### PR TITLE
mycima: remove episode_number

### DIFF
--- a/src/ar/mycima/build.gradle
+++ b/src/ar/mycima/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MY CIMA'
     pkgNameSuffix = 'ar.mycima'
     extClass = '.MyCima'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '12'
 }
 

--- a/src/ar/mycima/src/eu/kanade/tachiyomi/animeextension/ar/mycima/MyCima.kt
+++ b/src/ar/mycima/src/eu/kanade/tachiyomi/animeextension/ar/mycima/MyCima.kt
@@ -84,7 +84,7 @@ class MyCima : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     override fun episodeFromElement(element: Element): SEpisode {
         val episode = SEpisode.create()
         episode.setUrlWithoutDomain(element.attr("abs:href"))
-        episode.episode_number = element.text().removePrefix("موسم ").removePrefix("الحلقة ").replace("مدبلج", "").replace(" -", "").toFloat()
+        //episode.episode_number = element.text().removePrefix("موسم ").removePrefix("الحلقة ").replace("مدبلج", "").replace(" -", "").toFloat()
         episode.name = element.ownerDocument().select("div.List--Seasons--Episodes a.selected").text() + " : " + element.text()
         episode.date_upload = System.currentTimeMillis()
         return episode


### PR DESCRIPTION
remove episode_number due to errors because the episode number is associated with a lot of strings  that needs to be replaced

