### PR TITLE
Fixing DopeBox and Sflix

### DIFF
--- a/src/en/dopebox/build.gradle
+++ b/src/en/dopebox/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'DopeBox'
     pkgNameSuffix = 'en.dopebox'
     extClass = '.DopeBox'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '12'
 }
 

--- a/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBox.kt
+++ b/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBox.kt
@@ -85,9 +85,9 @@ class DopeBox : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             val seasonsElements = seasonsHtml.select("a.dropdown-item.ss-item")
             seasonsElements.forEach {
                 val seasonEpList = parseEpisodesFromSeries(it)
-                episodeList.addAll(seasonEpList)
-                episodeList = episodeList.reversed().toMutableList()
+                episodeList.addAll(seasonEpList)   
             }
+            episodeList = episodeList.reversed().toMutableList()
         } else {
             val movieUrl = "https://dopebox.to/ajax/movie/episodes/$id"
             val episode = SEpisode.create()

--- a/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBox.kt
+++ b/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBox.kt
@@ -70,7 +70,7 @@ class DopeBox : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val document = response.asJsoup()
-        val episodeList = mutableListOf<SEpisode>()
+        var episodeList = mutableListOf<SEpisode>()
         val infoElement = document.select("div.detail_page-watch")
         val id = infoElement.attr("data-id")
         val dataType = infoElement.attr("data-type") // Tv = 2 or movie = 1
@@ -86,6 +86,7 @@ class DopeBox : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             seasonsElements.forEach {
                 val seasonEpList = parseEpisodesFromSeries(it)
                 episodeList.addAll(seasonEpList)
+                episodeList = episodeList.reversed().toMutableList()
             }
         } else {
             val movieUrl = "https://dopebox.to/ajax/movie/episodes/$id"

--- a/src/en/sflix/build.gradle
+++ b/src/en/sflix/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Sflix'
     pkgNameSuffix = 'en.sflix'
     extClass = '.SFlix'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '12'
 }
 

--- a/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlix.kt
+++ b/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlix.kt
@@ -86,8 +86,8 @@ class SFlix : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             seasonsElements.forEach {
                 val seasonEpList = parseEpisodesFromSeries(it)
                 episodeList.addAll(seasonEpList)
-                episodeList = episodeList.reversed().toMutableList()
             }
+            episodeList = episodeList.reversed().toMutableList()
         } else {
             val movieUrl = "https://sflix.to/ajax/movie/episodes/$id"
             val episode = SEpisode.create()

--- a/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlix.kt
+++ b/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlix.kt
@@ -70,7 +70,7 @@ class SFlix : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override fun episodeListParse(response: Response): List<SEpisode> {
         val document = response.asJsoup()
-        val episodeList = mutableListOf<SEpisode>()
+        var episodeList = mutableListOf<SEpisode>()
         val infoElement = document.select("div.detail_page-watch")
         val id = infoElement.attr("data-id")
         val dataType = infoElement.attr("data-type") // Tv = 2 or movie = 1
@@ -86,6 +86,7 @@ class SFlix : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             seasonsElements.forEach {
                 val seasonEpList = parseEpisodesFromSeries(it)
                 episodeList.addAll(seasonEpList)
+                episodeList = episodeList.reversed().toMutableList()
             }
         } else {
             val movieUrl = "https://sflix.to/ajax/movie/episodes/$id"


### PR DESCRIPTION
As both of the extensions are basically the same, I will just refer to DopeBox


DopeBox had an episode listing error, wherein the episode list would show up in a reverse order than what we are used to. This caused problems in the episode loaders of the player as well. 

It would move up an episode and a season at the same time.

So from Season 1 Episode 5, next would become Season 2 Episode 6, with no previous episode existing.

A simple reversing of the episode list ,before pushing to the user, fixed both the problems! 

<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
