### PR TITLE
9anime: fix for plus characters in episode urls

### DIFF
--- a/src/en/nineanime/build.gradle
+++ b/src/en/nineanime/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = '9anime'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.NineAnime'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '12'
 }
 

--- a/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnime.kt
+++ b/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnime.kt
@@ -101,7 +101,7 @@ class NineAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private fun episodeFromElement(element: Element, animeId: String, vrf: String): SEpisode {
         val episode = SEpisode.create()
         val epNum = element.attr("data-base")
-        episode.setUrlWithoutDomain("$baseUrl/ajax/anime/servers?id=$animeId&vrf=$vrf&episode=$epNum")
+        episode.url = "/ajax/anime/servers?id=$animeId&vrf=$vrf&episode=$epNum"
         episode.episode_number = epNum.toFloat()
         episode.name = "Episode $epNum"
         episode.date_upload = System.currentTimeMillis()


### PR DESCRIPTION
If the vrf query parameter in the episode url has escaped plus signs, setUrlWithoutDomain (when parsing with java.net.URI) unescapes them, which causes them to be treated as a space (probably) and causes loading episodes to fail with an unable to bypass cloudflare message

This may close #393, but there's not enough detail for me to be sure of that.