### PR TITLE
Combine gogo and dood videos to one list

### DIFF
--- a/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
+++ b/src/en/gogoanime/src/eu/kanade/tachiyomi/animeextension/en/gogoanime/GogoAnime.kt
@@ -93,9 +93,8 @@ class GogoAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val doodUrl = document.select("div.anime_muti_link > ul > li.doodstream > a")
             .attr("data-video")
         val gogoVideos = GogoCdnExtractor(client, json).videosFromUrl(serverUrl)
-        return gogoVideos.ifEmpty {
-            DoodExtractor(client).videosFromUrl(doodUrl)
-        }
+        val doodVideos = DoodExtractor(client).videosFromUrl(doodUrl)
+        return gogoVideos + doodVideos
     }
 
     override fun videoListSelector() = throw Exception("not used")


### PR DESCRIPTION
Combines the gogo video list and dood video list into one.

That way if any problems occur in one, its much easier for users to switch to the mirror and continue watching. The extension can be fixed in the background while users dont get affected as much

Reason:- Shingeki no Kyojin season 4 part 2, latest ep 12 seems to not work when using the gogocdn link
It shows up as a link, but gives an error 404. so it gets stuck without returning an empty list

(Unless there is a specific reason that dood hasn't been added to the main list before? does it rate limit? )
<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
