### PR TITLE
AnimesVision: Fix GlobalVision urls

### DIFF
--- a/src/pt/animesvision/build.gradle
+++ b/src/pt/animesvision/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimesVision'
     pkgNameSuffix = 'pt.animesvision'
     extClass = '.AnimesVision'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '12'
 }
 

--- a/src/pt/animesvision/src/eu/kanade/tachiyomi/animeextension/pt/animesvision/extractors/GlobalVisionExtractor.kt
+++ b/src/pt/animesvision/src/eu/kanade/tachiyomi/animeextension/pt/animesvision/extractors/GlobalVisionExtractor.kt
@@ -14,7 +14,10 @@ class GlobalVisionExtractor {
         val qualities = mapOf("SD" to "480p", "HD" to "720p", "FULLHD" to "1080p")
         return qualities.mapNotNull { (qualityName, qualityStr) ->
             if (qualityName in players) {
-                val videoUrl = if ("480p" in url) url else url.replace("480p", qualityStr)
+                val videoUrl = when {
+                    qualityName == "SD" -> url
+                    else -> url.replace("480p", qualityStr)
+                }
                 Video(videoUrl, "$PREFIX $qualityName", videoUrl, null)
             } else { null }
         }


### PR DESCRIPTION
It was returning the same url in all videos/qualities xD

<!--
If you are updating extensions, please remember to:

- Update the `extVersionCode` value in `build.gradle`
- Annotate `Source` or `SourceFactory` classes with `@Nsfw` when appropriate
- Add the `containsNsfw = true` flag in `build.gradle` when appropriate

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
