### PR TITLE
9anime: fix search anime selector

### DIFF
--- a/src/en/nineanime/build.gradle
+++ b/src/en/nineanime/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = '9anime'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.NineAnime'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '13'
 }
 

--- a/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnime.kt
+++ b/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnime.kt
@@ -161,7 +161,7 @@ class NineAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override fun searchAnimeNextPageSelector(): String = "a.btn-primary.next:not(.disabled)"
 
-    override fun searchAnimeSelector(): String = "div.ani.items div"
+    override fun searchAnimeSelector(): String = "div.ani.items > div"
 
     override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request {
         val vrf = encodeVrf(query)


### PR DESCRIPTION
Changed search anime selector to only gets immediate div descendants of div with search results, rather than recursively. Should get rid of spurious search results.

I ran into the issue myself, but also checked later and noticed it is an open issue, thus it closes #702