### PR TITLE
9anime: Tag episodes with Sub/Dub

### DIFF
--- a/src/en/nineanime/build.gradle
+++ b/src/en/nineanime/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = '9anime'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.NineAnime'
-    extVersionCode = 14
+    extVersionCode = 15
     libVersion = '13'
 }
 

--- a/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnime.kt
+++ b/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnime.kt
@@ -84,18 +84,23 @@ class NineAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val episode = SEpisode.create()
         val epNum = element.attr("data-num")
         val ids = element.attr("data-ids")
+        val sub = element.attr("data-sub").toInt().toBoolean()
+        val dub = element.attr("data-dub").toInt().toBoolean()
         val vrf = encodeVrf(ids)
         episode.url = "/ajax/server/list/$ids?vrf=$vrf"
         episode.episode_number = epNum.toFloat()
+        val langPrefix = "["+ if(sub) {"Sub"} else {""} + if(dub) {",Dub"} else {""} + "]"
         val name = element.parent()?.select("span.d-title")?.text().orEmpty()
         val namePrefix = "Episode $epNum"
-        episode.name = if (name.isNotEmpty() && name != namePrefix) {
-            "Episode $epNum: $name"
-        } else {
-            "Episode $epNum"
-        }
+        episode.name = "Episode $epNum" + if(sub||dub){
+                ": $langPrefix"
+            }else{""} + if (name.isNotEmpty() && name != namePrefix) {
+                " $name"
+            }else{""}
         return episode
     }
+
+    private fun Int.toBoolean() = this == 1
 
     override fun videoListParse(response: Response): List<Video> {
         val responseObject = json.decodeFromString<JsonObject>(response.body!!.string())

--- a/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnime.kt
+++ b/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnime.kt
@@ -165,6 +165,18 @@ class NineAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                     newList.add(video)
                 }
             }
+            // If dub is preferred language and anime do not have dub version, respect preferred quality
+            if (lang == "Dub" && newList.first().quality.contains("Dub").not()) {
+                newList.clear()
+                for (video in this) {
+                    if (video.quality.contains(quality)) {
+                        newList.add(preferred, video)
+                        preferred++
+                    } else {
+                        newList.add(video)
+                    }
+                }
+            }
             return newList
         }
         return this


### PR DESCRIPTION
Instead of opening the episode and check for sub/dub in the video quality, episodes should be tagged with available language.

Currently episode name is the option but for future update, `SEpisode` should have an optional `sub` and `dub` flags that can be set by extensions and the app could show this flag appropriately. I can open a tracker(issue) in the app repo if this is acceptable?

And sorry for the flood of updates.