### PR TITLE
9anime: Fix endless loading

### DIFF
--- a/src/en/kickassanime/build.gradle
+++ b/src/en/kickassanime/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'KickAssAnime'
     pkgNameSuffix = 'en.kickassanime'
     extClass = '.KickAssAnime'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -235,11 +235,11 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             anime.status = parseStatus(ani["status"]!!.jsonPrimitive.content)
 
             val altName = "Other name(s): "
-            ani["alternate"]!!.jsonArray.let { jsonArray ->
-                if (jsonArray.isEmpty().not()) {
+            json.decodeFromString<JsonArray>(ani["alternate"].toString().replace("\"\"", "[]")).let { altArray ->
+                if (altArray.isEmpty().not()) {
                     anime.description = when {
-                        anime.description.isNullOrBlank() -> altName + jsonArray.joinToString { it.jsonPrimitive.content }
-                        else -> anime.description + "\n\n$altName" + jsonArray.joinToString { it.jsonPrimitive.content }
+                        anime.description.isNullOrBlank() -> altName + altArray.joinToString { it.jsonPrimitive.content }
+                        else -> anime.description + "\n\n$altName" + altArray.joinToString { it.jsonPrimitive.content }
                     }
                 }
             }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

`animeDetailsParse` loop while erroring when alternative name is returned as empty string instead empty array from the server.
