### PR TITLE
anime4up, xsanime, xsmovies: some fixes

### DIFF
--- a/src/ar/anime4up/build.gradle
+++ b/src/ar/anime4up/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Anime4up'
     pkgNameSuffix = 'ar.anime4up'
     extClass = '.Anime4Up'
-    extVersionCode = 29
+    extVersionCode = 30
     libVersion = '13'
 }
 

--- a/src/ar/anime4up/src/eu/kanade/tachiyomi/animeextension/ar/anime4up/Anime4Up.kt
+++ b/src/ar/anime4up/src/eu/kanade/tachiyomi/animeextension/ar/anime4up/Anime4Up.kt
@@ -30,7 +30,7 @@ class Anime4Up : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Anime4Up"
 
-    override val baseUrl = "https://anime4up.art"
+    override val baseUrl = "https://anime4up.vip"
 
     override val lang = "ar"
 
@@ -44,7 +44,7 @@ class Anime4Up : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override fun headersBuilder(): Headers.Builder {
         return super.headersBuilder()
-            .add("Referer", "https://anime4up.art/") // https://s12.gemzawy.com https://moshahda.net
+            .add("Referer", "https://anime4up.vip/") // https://s12.gemzawy.com https://moshahda.net
     }
 
     // Popular

--- a/src/ar/xsanime/build.gradle
+++ b/src/ar/xsanime/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'XS Anime'
     pkgNameSuffix = 'ar.xsanime'
     extClass = '.XsAnime'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '13'
 }
 

--- a/src/ar/xsanime/src/eu/kanade/tachiyomi/animeextension/ar/xsanime/XsAnime.kt
+++ b/src/ar/xsanime/src/eu/kanade/tachiyomi/animeextension/ar/xsanime/XsAnime.kt
@@ -49,7 +49,7 @@ class XsAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val anime = SAnime.create()
         anime.setUrlWithoutDomain(element.attr("href"))
         anime.title = element.attr("title")
-        anime.thumbnail_url = element.select("div.itemtype_anime_poster img").first().attr("abs:src")
+        anime.thumbnail_url = element.select("div.itemtype_anime_poster img").first().attr("data-src")
         return anime
     }
 
@@ -103,7 +103,7 @@ class XsAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val anime = SAnime.create()
         anime.setUrlWithoutDomain(element.attr("href"))
         anime.title = element.attr("title")
-        anime.thumbnail_url = element.select("div.itemtype_anime_poster img").first().attr("abs:src")
+        anime.thumbnail_url = element.select("div.itemtype_anime_poster img").first().attr("data-src")
         return anime
     }
 

--- a/src/ar/xsmovie/build.gradle
+++ b/src/ar/xsmovie/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'XS Movie'
     pkgNameSuffix = 'ar.xsmovie'
     extClass = '.XsMovie'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '13'
 }
 

--- a/src/ar/xsmovie/src/eu/kanade/tachiyomi/animeextension/ar/xsmovie/XsMovie.kt
+++ b/src/ar/xsmovie/src/eu/kanade/tachiyomi/animeextension/ar/xsmovie/XsMovie.kt
@@ -47,7 +47,7 @@ class XsMovie : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val anime = SAnime.create()
         anime.setUrlWithoutDomain(element.attr("href"))
         anime.title = element.attr("title")
-        anime.thumbnail_url = element.select("div.itemtype_anime_poster img").first().attr("abs:src")
+        anime.thumbnail_url = element.select("div.itemtype_anime_poster img").first().attr("data-src")
         return anime
     }
 
@@ -91,7 +91,7 @@ class XsMovie : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val anime = SAnime.create()
         anime.setUrlWithoutDomain(element.attr("href"))
         anime.title = element.attr("title")
-        anime.thumbnail_url = element.select("div.itemtype_anime_poster img").first().attr("abs:src")
+        anime.thumbnail_url = element.select("div.itemtype_anime_poster img").first().attr("data-src")
         return anime
     }
 


### PR DESCRIPTION
anime4up: update site BaseUrl
xsanime, xsmovies: fix thumbnail_url  selectors

Checklist:
- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
