### PR TITLE
AnimeWorld: handle streamingaw.online server 

### DIFF
--- a/src/it/animeworld/build.gradle
+++ b/src/it/animeworld/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'ANIMEWORLD.tv'
     pkgNameSuffix = 'it.animeworld'
     extClass = '.ANIMEWORLD'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '13'
 }
 

--- a/src/it/animeworld/src/eu/kanade/tachiyomi/animeextension/it/animeworld/ANIMEWORLD.kt
+++ b/src/it/animeworld/src/eu/kanade/tachiyomi/animeextension/it/animeworld/ANIMEWORLD.kt
@@ -85,10 +85,14 @@ class ANIMEWORLD : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         return videosFromElement(document)
     }
 
-    override fun videoListSelector() = "center a[href*=dood], center a[href*=streamtape], center a[href*=animeworld.biz]"
+    override fun videoListSelector() = "center a[href*=dood], center a[href*=streamtape], center a[href*=animeworld.biz], center a[href*=streamingaw.online][id=alternativeDownloadLink]"
 
     private fun videosFromElement(document: Document): List<Video> {
         val videoList = mutableListOf<Video>()
+        // afaik this element appears when videos are taken down, in this case instead of
+        // displaying Videolist empty show the element's text
+        val copyrightError = document.select("div.alert.alert-primary:contains(Copyright)")
+        if (copyrightError.hasText()) throw Exception(copyrightError.text())
         val elements = document.select(videoListSelector())
         for (element in elements) {
             val url = element.attr("href")
@@ -111,6 +115,11 @@ class ANIMEWORLD : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                         .build()
                     val videos = StreamSBExtractor(client).videosFromUrl(url.replace("/d/", "/e/"), headers)
                     videoList.addAll(videos)
+                }
+                url.contains("streamingaw") -> {
+                    videoList.add(
+                        Video(url, "AnimeWorld Server", url)
+                    )
                 }
                 url.contains("dood") -> {
                     val video = DoodExtractor(client).videoFromUrl(url.replace("/d/", "/e/"))


### PR DESCRIPTION
closes #735
And throw a clear error message when video's are taken down due to copyright.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
