### PR TITLE
Change `IOException` to `Exception` in FembedExtractor 

### DIFF
--- a/src/es/animefenix/build.gradle
+++ b/src/es/animefenix/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Animefenix'
     pkgNameSuffix = 'es.animefenix'
     extClass = '.Animefenix'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '13'
 }
 

--- a/src/es/animefenix/src/eu/kanade/tachiyomi/animeextension/es/animefenix/extractors/FembedExtractor.kt
+++ b/src/es/animefenix/src/eu/kanade/tachiyomi/animeextension/es/animefenix/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {
@@ -21,7 +20,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/animeflv/build.gradle
+++ b/src/es/animeflv/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'AnimeFLV'
     pkgNameSuffix = 'es.animeflv'
     extClass = '.AnimeFlv'
-    extVersionCode = 26
+    extVersionCode = 27
     libVersion = '13'
 }
 

--- a/src/es/animeflv/src/eu/kanade/tachiyomi/animeextension/es/animeflv/extractors/FembedExtractor.kt
+++ b/src/es/animeflv/src/eu/kanade/tachiyomi/animeextension/es/animeflv/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/animeflv/src/eu/kanade/tachiyomi/animeextension/es/animeflv/extractors/FembedExtractor.kt
+++ b/src/es/animeflv/src/eu/kanade/tachiyomi/animeextension/es/animeflv/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/animelatinohd/build.gradle
+++ b/src/es/animelatinohd/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'AnimeLatinoHD'
     pkgNameSuffix = 'es.animelatinohd'
     extClass = '.AnimeLatinoHD'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '13'
 }
 

--- a/src/es/animelatinohd/src/eu/kanade/tachiyomi/animeextension/es/animelatinohd/extractors/FembedExtractor.kt
+++ b/src/es/animelatinohd/src/eu/kanade/tachiyomi/animeextension/es/animelatinohd/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/animelatinohd/src/eu/kanade/tachiyomi/animeextension/es/animelatinohd/extractors/FembedExtractor.kt
+++ b/src/es/animelatinohd/src/eu/kanade/tachiyomi/animeextension/es/animelatinohd/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/animeonlineninja/src/eu/kanade/tachiyomi/animeextension/es/animeonlineninja/extractors/FembedExtractor.kt
+++ b/src/es/animeonlineninja/src/eu/kanade/tachiyomi/animeextension/es/animeonlineninja/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {
@@ -21,7 +20,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/asialiveaction/build.gradle
+++ b/src/es/asialiveaction/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'AsiaLiveAction'
     pkgNameSuffix = 'es.asialiveaction'
     extClass = '.AsiaLiveAction'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '13'
 }
 

--- a/src/es/asialiveaction/src/eu/kanade/tachiyomi/animeextension/es/asialiveaction/extractors/FembedExtractor.kt
+++ b/src/es/asialiveaction/src/eu/kanade/tachiyomi/animeextension/es/asialiveaction/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/asialiveaction/src/eu/kanade/tachiyomi/animeextension/es/asialiveaction/extractors/FembedExtractor.kt
+++ b/src/es/asialiveaction/src/eu/kanade/tachiyomi/animeextension/es/asialiveaction/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/doramasyt/build.gradle
+++ b/src/es/doramasyt/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Doramasyt'
     pkgNameSuffix = 'es.doramasyt'
     extClass = '.Doramasyt'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '13'
 }
 

--- a/src/es/doramasyt/src/eu/kanade/tachiyomi/animeextension/es/doramasyt/extractors/FembedExtractor.kt
+++ b/src/es/doramasyt/src/eu/kanade/tachiyomi/animeextension/es/doramasyt/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/doramasyt/src/eu/kanade/tachiyomi/animeextension/es/doramasyt/extractors/FembedExtractor.kt
+++ b/src/es/doramasyt/src/eu/kanade/tachiyomi/animeextension/es/doramasyt/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/hentaijk/build.gradle
+++ b/src/es/hentaijk/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Hentaijk'
     pkgNameSuffix = 'es.hentaijk'
     extClass = '.Hentaijk'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/es/hentaijk/src/eu/kanade/tachiyomi/animeextension/es/hentaijk/extractors/FembedExtractor.kt
+++ b/src/es/hentaijk/src/eu/kanade/tachiyomi/animeextension/es/hentaijk/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/hentaijk/src/eu/kanade/tachiyomi/animeextension/es/hentaijk/extractors/FembedExtractor.kt
+++ b/src/es/hentaijk/src/eu/kanade/tachiyomi/animeextension/es/hentaijk/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/hentaila/build.gradle
+++ b/src/es/hentaila/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Hentaila'
     pkgNameSuffix = 'es.hentaila'
     extClass = '.Hentaila'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/es/hentaila/src/eu/kanade/tachiyomi/animeextension/es/hentaila/extractors/FembedExtractor.kt
+++ b/src/es/hentaila/src/eu/kanade/tachiyomi/animeextension/es/hentaila/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/hentaila/src/eu/kanade/tachiyomi/animeextension/es/hentaila/extractors/FembedExtractor.kt
+++ b/src/es/hentaila/src/eu/kanade/tachiyomi/animeextension/es/hentaila/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/jkanime/build.gradle
+++ b/src/es/jkanime/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Jkanime'
     pkgNameSuffix = 'es.jkanime'
     extClass = '.Jkanime'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '13'
 }
 

--- a/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/extractors/FembedExtractor.kt
+++ b/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/extractors/FembedExtractor.kt
+++ b/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/jkhentai/build.gradle
+++ b/src/es/jkhentai/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Jkhentai'
     pkgNameSuffix = 'es.jkhentai'
     extClass = '.Jkhentai'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/es/jkhentai/src/eu/kanade/tachiyomi/animeextension/es/jkhentai/extractors/FembedExtractor.kt
+++ b/src/es/jkhentai/src/eu/kanade/tachiyomi/animeextension/es/jkhentai/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/jkhentai/src/eu/kanade/tachiyomi/animeextension/es/jkhentai/extractors/FembedExtractor.kt
+++ b/src/es/jkhentai/src/eu/kanade/tachiyomi/animeextension/es/jkhentai/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/monoschinos/build.gradle
+++ b/src/es/monoschinos/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MonosChinos'
     pkgNameSuffix = 'es.monoschinos'
     extClass = '.MonosChinos'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '13'
 }
 

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/extractors/FembedExtractor.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/extractors/FembedExtractor.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/mundodonghua/build.gradle
+++ b/src/es/mundodonghua/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MundoDonghua'
     pkgNameSuffix = 'es.mundodonghua'
     extClass = '.MundoDonghua'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '13'
 }
 

--- a/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/extractors/FembedExtractor.kt
+++ b/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/extractors/FembedExtractor.kt
+++ b/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/pelisflix/build.gradle
+++ b/src/es/pelisflix/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Pelisflix'
     pkgNameSuffix = 'es.pelisflix'
     extClass = '.PelisflixFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '13'
 }
 

--- a/src/es/pelisflix/src/eu/kanade/tachiyomi/animeextension/es/pelisflix/extractors/FembedExtractor.kt
+++ b/src/es/pelisflix/src/eu/kanade/tachiyomi/animeextension/es/pelisflix/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/pelisflix/src/eu/kanade/tachiyomi/animeextension/es/pelisflix/extractors/FembedExtractor.kt
+++ b/src/es/pelisflix/src/eu/kanade/tachiyomi/animeextension/es/pelisflix/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/pelisplushd/build.gradle
+++ b/src/es/pelisplushd/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Pelisplushd'
     pkgNameSuffix = 'es.pelisplushd'
     extClass = '.Pelisplushd'
-    extVersionCode = 16
+    extVersionCode = 17
     libVersion = '13'
 }
 

--- a/src/es/pelisplushd/src/eu/kanade/tachiyomi/animeextension/es/pelisplushd/extractors/FembedExtractor.kt
+++ b/src/es/pelisplushd/src/eu/kanade/tachiyomi/animeextension/es/pelisplushd/extractors/FembedExtractor.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/pelisplushd/src/eu/kanade/tachiyomi/animeextension/es/pelisplushd/extractors/FembedExtractor.kt
+++ b/src/es/pelisplushd/src/eu/kanade/tachiyomi/animeextension/es/pelisplushd/extractors/FembedExtractor.kt
@@ -21,7 +21,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }

--- a/src/es/tioanime/build.gradle
+++ b/src/es/tioanime/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'TioanimeH'
     pkgNameSuffix = 'es.tioanimeh'
     extClass = '.TioanimeHFactory'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '13'
 }
 

--- a/src/es/tioanime/src/eu/kanade/tachiyomi/animeextension/es/tioanimeh/extractors/FembedExtractor.kt
+++ b/src/es/tioanime/src/eu/kanade/tachiyomi/animeextension/es/tioanimeh/extractors/FembedExtractor.kt
@@ -3,7 +3,6 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import org.json.JSONObject
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import java.io.IOException
 
 class FembedExtractor {
     fun videosFromUrl(url: String, qualityPrefix: String = ""): List<Video> {

--- a/src/es/tioanime/src/eu/kanade/tachiyomi/animeextension/es/tioanimeh/extractors/FembedExtractor.kt
+++ b/src/es/tioanime/src/eu/kanade/tachiyomi/animeextension/es/tioanimeh/extractors/FembedExtractor.kt
@@ -20,7 +20,7 @@ class FembedExtractor {
                 videoList.add(Video(videoUrl, quality, videoUrl))
             }
             videoList
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             videoList
         }
     }


### PR DESCRIPTION
in some videos it gives an error and everything goes to shit. 
ex:
https://fembed.com/v/05nw4sljdyn2nly

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
