### PR TITLE
Hentaimama episode parsing fix

### DIFF
--- a/src/en/hentaimama/src/eu/kanade/tachiyomi/animeextension/en/hentaimama/HentaiMama.kt
+++ b/src/en/hentaimama/src/eu/kanade/tachiyomi/animeextension/en/hentaimama/HentaiMama.kt
@@ -73,15 +73,16 @@ class HentaiMama : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override fun episodeFromElement(element: Element): SEpisode {
         val episode = SEpisode.create()
-        val epNum = element.select("div.season_m a span.c").text().removePrefix("Episode ")
+        val epNumPattern = Regex("Episode (\\d+\\.?\\d*)")
+        val epNumMatch = epNumPattern.find(element.select("div.season_m a span.c").text())
+        episode.episode_number = when {
+            (epNumMatch != null) -> epNumMatch.groups[1]!!.value.toFloat()
+            else -> 1F
+        }
         val date = SimpleDateFormat("MMM. dd, yyyy").parse(element.select("div.data > span").text())
         episode.setUrlWithoutDomain(element.select("div.season_m a").attr("href"))
         episode.name = element.select("div.data h3").text()
         episode.date_upload = date.time
-        episode.episode_number = when {
-            (epNum.isNotEmpty()) -> epNum.toFloat()
-            else -> 1F
-        }
 
         return episode
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Closes #892