### PR TITLE
Dopebox: fix URL error

### DIFF
--- a/src/en/dopebox/build.gradle
+++ b/src/en/dopebox/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'DopeBox'
     pkgNameSuffix = 'en.dopebox'
     extClass = '.DopeBox'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '13'
 }
 

--- a/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBox.kt
+++ b/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBox.kt
@@ -432,7 +432,7 @@ class DopeBox : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         }
 
     companion object {
-        private const val PREF_DOMAIN_KEY = "preferred_domain"
+        private const val PREF_DOMAIN_KEY = "preferred_domain_new"
         private const val PREF_DOMAIN_TITLE = "Preferred domain (requires app restart)"
         private val PREF_DOMAIN_LIST = arrayOf("dopebox.to", "dopebox.se")
 


### PR DESCRIPTION
Closes #910
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio 
