### PR TITLE
Zoro: Add Sub/Dub status to description

### DIFF
--- a/src/en/zoro/build.gradle
+++ b/src/en/zoro/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'zoro.to (experimental)'
     pkgNameSuffix = 'en.zoro'
     extClass = '.Zoro'
-    extVersionCode = 12
+    extVersionCode = 13
     libVersion = '13'
 }
 

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/Zoro.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/Zoro.kt
@@ -228,7 +228,7 @@ class Zoro : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         return tracks
     }
 
-    // =============================== Search =============================== 
+    // =============================== Search ===============================
     override fun searchAnimeFromElement(element: Element) = popularAnimeFromElement(element)
 
     override fun searchAnimeNextPageSelector(): String = popularAnimeNextPageSelector()
@@ -287,12 +287,16 @@ class Zoro : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     override fun animeDetailsParse(document: Document): SAnime {
         val anime = SAnime.create()
         val info = document.selectFirst("div.anisc-info")
+        val detail = document.selectFirst("div.anisc-detail")
         anime.thumbnail_url = document.selectFirst("div.anisc-poster img").attr("src")
-        anime.title = document.selectFirst("div.anisc-detail h2").attr("data-jname")
+        anime.title = detail.selectFirst("h2").attr("data-jname")
         anime.author = info.getInfo("Studios:")
         anime.status = parseStatus(info.getInfo("Status:"))
         anime.genre = info.getInfo("Genres:", isList = true)
         var description = info.getInfo("Overview:")?.let { it + "\n" } ?: ""
+        detail.select("div.film-stats div.tick-dub")?.let {
+            description += "\nLanguage: " + it.joinToString(", ") { lang -> lang.text() }
+        }
         info.getInfo("Aired:", full = true)?.let { description += it }
         info.getInfo("Premiered:", full = true)?.let { description += it }
         info.getInfo("Synonyms:", full = true)?.let { description += it }


### PR DESCRIPTION
Individual episodes are not tagged with language status

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
