### PR TITLE
SFlix/Dopebox: fix error 404 and default url

### DIFF
--- a/src/en/dopebox/build.gradle
+++ b/src/en/dopebox/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'DopeBox'
     pkgNameSuffix = 'en.dopebox'
     extClass = '.DopeBox'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '13'
 }
 

--- a/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBox.kt
+++ b/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBox.kt
@@ -407,7 +407,7 @@ class DopeBox : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             title = PREF_POPULAR_TITLE
             entries = PREF_POPULAR_ENTRIES
             entryValues = PREF_POPULAR_VALUES
-            setDefaultValue("Movies")
+            setDefaultValue("movie")
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -452,7 +452,7 @@ class DopeBox : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         private const val PREF_LATEST_TITLE = "Preferred latest page"
         private val PREF_LATEST_PAGES = arrayOf("Movies", "TV Shows")
 
-        private const val PREF_POPULAR_KEY = "preferred_popular_page"
+        private const val PREF_POPULAR_KEY = "preferred_popular_page_new"
         private const val PREF_POPULAR_TITLE = "Preferred popular page"
         private val PREF_POPULAR_ENTRIES = PREF_LATEST_PAGES
         private val PREF_POPULAR_VALUES = arrayOf("movie", "tv-show")

--- a/src/en/sflix/build.gradle
+++ b/src/en/sflix/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Sflix'
     pkgNameSuffix = 'en.sflix'
     extClass = '.SFlix'
-    extVersionCode = 12
+    extVersionCode = 13
     libVersion = '13'
 }
 

--- a/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlix.kt
+++ b/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlix.kt
@@ -407,7 +407,7 @@ class SFlix : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             title = PREF_POPULAR_TITLE
             entries = PREF_POPULAR_ENTRIES
             entryValues = PREF_POPULAR_VALUES
-            setDefaultValue("Movies")
+            setDefaultValue("movie")
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -452,7 +452,7 @@ class SFlix : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         private const val PREF_LATEST_TITLE = "Preferred latest page"
         private val PREF_LATEST_PAGES = arrayOf("Movies", "TV Shows")
 
-        private const val PREF_POPULAR_KEY = "preferred_popular_page"
+        private const val PREF_POPULAR_KEY = "preferred_popular_page_new"
         private const val PREF_POPULAR_TITLE = "Preferred popular page"
         private val PREF_POPULAR_ENTRIES = PREF_LATEST_PAGES
         private val PREF_POPULAR_VALUES = arrayOf("movie", "tv-show")

--- a/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlix.kt
+++ b/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlix.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.SharedPreferences
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
-import eu.kanade.tachiyomi.lib.doodextractor.DoodExtractor
 import eu.kanade.tachiyomi.animeextension.en.sflix.extractors.SFlixExtractor
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.model.AnimeFilterList
@@ -14,6 +13,7 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
+import eu.kanade.tachiyomi.lib.doodextractor.DoodExtractor
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.util.asJsoup
@@ -44,7 +44,7 @@ class SFlix : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     override val name = "SFlix"
 
     override val baseUrl by lazy {
-        "https://" + preferences.getString(PREF_DOMAIN_KEY, "dopebox.to")!!
+        "https://" + preferences.getString(PREF_DOMAIN_KEY, "sflix.to")!!
     }
 
     override val lang = "en"
@@ -347,7 +347,7 @@ class SFlix : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             title = PREF_DOMAIN_TITLE
             entries = PREF_DOMAIN_LIST
             entryValues = PREF_DOMAIN_LIST
-            setDefaultValue("dopebox.to")
+            setDefaultValue("sflix.to")
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->


### PR DESCRIPTION
This fixes an error detected at #914 review, and another error reported on discord.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
