### PR TITLE
Convert StreamSBExtractor to shared lib

### DIFF
--- a/lib/streamsb-extractor/build.gradle.kts
+++ b/lib/streamsb-extractor/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+}
+
+android {
+    compileSdk = AndroidConfig.compileSdk
+
+    defaultConfig {
+        minSdk = AndroidConfig.minSdk
+        targetSdk = AndroidConfig.targetSdk
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(libs.kotlin.stdlib)
+    compileOnly(libs.kotlin.json)
+    compileOnly(libs.okhttp)
+    compileOnly(libs.aniyomi.lib)
+}
+// BUMPS: 0

--- a/lib/streamsb-extractor/src/main/AndroidManifest.xml
+++ b/lib/streamsb-extractor/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="eu.kanade.tachiyomi.lib.streamsbextractor" />

--- a/lib/streamsb-extractor/src/main/java/eu/kanade/tachiyomi/lib/streamsbextractor/StreamSBExtractor.kt
+++ b/lib/streamsb-extractor/src/main/java/eu/kanade/tachiyomi/lib/streamsbextractor/StreamSBExtractor.kt
@@ -1,0 +1,76 @@
+package eu.kanade.tachiyomi.lib.streamsbextractor
+
+import eu.kanade.tachiyomi.animesource.model.Video
+import eu.kanade.tachiyomi.network.GET
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+
+class StreamSBExtractor(private val client: OkHttpClient) {
+
+    protected fun bytesToHex(bytes: ByteArray): String {
+        val hexArray = "0123456789ABCDEF".toCharArray()
+        val hexChars = CharArray(bytes.size * 2)
+        for (j in bytes.indices) {
+            val v = bytes[j].toInt() and 0xFF
+
+            hexChars[j * 2] = hexArray[v ushr 4]
+            hexChars[j * 2 + 1] = hexArray[v and 0x0F]
+        }
+        return String(hexChars)
+    }
+
+    // animension, asianload and dramacool uses "common = false"
+    private fun fixUrl(url: String, common: Boolean): String {
+        val sbUrl = url.substringBefore("/e/")
+        val id = url.substringAfter("/e/")
+            .substringBefore("?")
+            .substringBefore(".html")
+        return if (common) {
+            val hexBytes = bytesToHex(id.toByteArray())
+            "$sbUrl/sources48/625a364258615242766475327c7c${hexBytes}7c7c4761574550654f7461566d347c7c73747265616d7362"
+        } else {
+            "$sbUrl/sources48/${bytesToHex("||$id||||streamsb".toByteArray())}/"
+        }
+    }
+
+    fun videosFromUrl(url: String, headers: Headers, prefix: String = "", suffix: String = "", common: Boolean = true): List<Video> {
+        val newHeaders = headers.newBuilder()
+            .set("referer", url)
+            .set("watchsb", "sbstream")
+            .set("authority", "embedsb.com")
+            .build()
+        return try {
+            val master = fixUrl(url, common)
+            val json = Json.decodeFromString<JsonObject>(
+                client.newCall(GET(master, newHeaders))
+                    .execute().body!!.string()
+            )
+            val masterUrl = json["stream_data"]!!.jsonObject["file"].toString().trim('"')
+            val masterPlaylist = client.newCall(GET(masterUrl, newHeaders))
+                .execute()
+                .body!!.string()
+            val separator = "#EXT-X-STREAM-INF"
+            masterPlaylist.substringAfter(separator).split(separator).map {
+                val resolution = it.substringAfter("RESOLUTION=")
+                    .substringBefore("\n")
+                    .substringAfter("x")
+                    .substringBefore(",") + "p"
+                val quality = ("StreamSB:" + resolution).let {
+                    if(prefix.isNotBlank()) "$prefix $it"
+                    else it
+                }.let {
+                    if(suffix.isNotBlank()) "$it $suffix"
+                    else it
+                }
+                val videoUrl = it.substringAfter("\n").substringBefore("\n")
+                Video(videoUrl, quality, videoUrl, headers = newHeaders)
+            }
+        } catch (e: Exception) {
+            emptyList<Video>()
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,9 @@
 include(":core")
 
-listOf("dataimage", "dood-extractor").forEach {
-    include(":lib-$it")
-    project(":lib-$it").projectDir = File("lib/$it")
+File(rootDir, "lib").eachDir {
+    val libName = it.name
+    include(":lib-$libName")
+    project(":lib-$libName").projectDir = File("lib/$libName")
 }
 
 if (System.getenv("CI") == null || System.getenv("CI_MODULE_GEN") == "true") {


### PR DESCRIPTION
I just did the conversion and didn't touch the extensions that use this extractor: the idea is that in their next update, the maintainer should remove the old extractor file and start using the shared lib.
I have a commit that does the same as the last conversion PR (= puts the lib in all extensions that use the extractor), but I didn't submit it because that would update several extensions unnecessarily, since this is closer to a refactor than to a bugfix.
BUT if that is not considered a problem, I can send it as soon as possible 👍