### PR TITLE
FembedExtractor: Prevent exceptions

### DIFF
--- a/lib/fembed-extractor/src/main/java/eu/kanade/tachiyomi/lib/fembedextractor/FembedExtractor.kt
+++ b/lib/fembed-extractor/src/main/java/eu/kanade/tachiyomi/lib/fembedextractor/FembedExtractor.kt
@@ -9,8 +9,9 @@ import okhttp3.OkHttpClient
 class FembedExtractor(private val client: OkHttpClient) {
     fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
         val videoApi = url.replace("/v/", "/api/source/")
-        val body = client.newCall(POST(videoApi)).execute()
-            .body?.string().orEmpty()
+        val body = runCatching {
+            client.newCall(POST(videoApi)).execute().body?.string().orEmpty()
+        }.getOrNull() ?: return emptyList<Video>()
 
         val jsonResponse = Json { ignoreUnknownKeys = true }
             .decodeFromString<FembedResponse>(body)

--- a/src/pt/vizer/src/eu/kanade/tachiyomi/animeextension/pt/vizer/Vizer.kt
+++ b/src/pt/vizer/src/eu/kanade/tachiyomi/animeextension/pt/vizer/Vizer.kt
@@ -170,10 +170,8 @@ class Vizer : ConfigurableAnimeSource, AnimeHttpSource() {
                     StreamTapeExtractor(client)
                         .videoFromUrl(url, "StreamTape($langPrefix)")?.let(::listOf)
                 name == "fembed" ->
-                    runCatching {
-                        FembedExtractor(client)
-                            .videosFromUrl(url, langPrefix)
-                    }.getOrNull()
+                    FembedExtractor(client)
+                        .videosFromUrl(url, langPrefix)
                 else -> null
             }
         }.flatten()


### PR DESCRIPTION
FembedExtractor can throw exceptions if cloudflare wants to ruin everything or if the url is invalid (= http 403 forbidden), and this has the potential to break extensions that may use it when trying to get the video list.

WitAnime and Vizer.tv are going to be bumped by the autobump script on workflow, this time it's not an unnecessary update xD