### PR TITLE
Vidembed: add referer to mixdrop extractor to fix 403

### DIFF
--- a/src/en/vidembed/build.gradle
+++ b/src/en/vidembed/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Vidembed'
     pkgNameSuffix = 'en.vidembed'
     extClass = '.Vidembed'
-    extVersionCode = 17
+    extVersionCode = 18
     libVersion = '13'
 }
 

--- a/src/en/vidembed/src/eu/kanade/tachiyomi/animeextension/en/vidembed/extractors/MixDropExtractor.kt
+++ b/src/en/vidembed/src/eu/kanade/tachiyomi/animeextension/en/vidembed/extractors/MixDropExtractor.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.OkHttpClient
+import okhttp3.Headers
 
 //From Vizer Extension
 class MixDropExtractor(private val client: OkHttpClient) {
@@ -21,6 +22,7 @@ class MixDropExtractor(private val client: OkHttpClient) {
                 "$it($lang)"
             } else it
         }
-        return listOf(Video(url, quality, videoUrl))
+        val referer = Headers.headersOf("Referer", "https://mixdrop.co/")
+        return listOf(Video(url, quality, videoUrl, headers = referer))
     }
 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
