### PR TITLE
Rename Vidembed to Membed

### DIFF
--- a/src/en/vidembed/build.gradle
+++ b/src/en/vidembed/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlinx-serialization'
 
 ext {
-    extName = 'Vidembed'
+    extName = 'Membed'
     pkgNameSuffix = 'en.vidembed'
-    extClass = '.Vidembed'
-    extVersionCode = 18
+    extClass = '.Membed'
+    extVersionCode = 19
     libVersion = '13'
 }
 

--- a/src/en/vidembed/src/eu/kanade/tachiyomi/animeextension/en/vidembed/Membed.kt
+++ b/src/en/vidembed/src/eu/kanade/tachiyomi/animeextension/en/vidembed/Membed.kt
@@ -32,11 +32,11 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.lang.Exception
 
-class Vidembed : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
+class Membed : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
-    override val name = "Vidembed"
+    override val name = "Membed"
 
-    override val baseUrl = "https://vidembed.io"
+    override val baseUrl = "https://membed.net"
 
     override val lang = "en"
 
@@ -44,11 +44,13 @@ class Vidembed : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val client: OkHttpClient = network.cloudflareClient
 
+    override val id: Long = 8093842542096095331
+
     private val json = Json {
         ignoreUnknownKeys = true
     }
 
-    private val downloadLink = "https://vidembed.io/download?id="
+    private val downloadLink = "https://membed.net/download?id="
 
     private val preferences: SharedPreferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)


### PR DESCRIPTION
Hope this is the right way to rename an extension.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
