### PR TITLE
[Multiple sources] Fix "List is empty" error on search

### DIFF
--- a/src/en/dopebox/build.gradle
+++ b/src/en/dopebox/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'DopeBox'
     pkgNameSuffix = 'en.dopebox'
     extClass = '.DopeBox'
-    extVersionCode = 15
+    extVersionCode = 16
     libVersion = '13'
 }
 

--- a/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBoxFilters.kt
+++ b/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/DopeBoxFilters.kt
@@ -72,6 +72,8 @@ object DopeBoxFilters {
     )
 
     internal fun getSearchParameters(filters: AnimeFilterList): FilterSearchParams {
+        if (filters.isEmpty()) return FilterSearchParams()
+
         return FilterSearchParams(
             filters.asQueryPart<TypeFilter>(),
             filters.asQueryPart<QualityFilter>(),

--- a/src/en/sflix/build.gradle
+++ b/src/en/sflix/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Sflix'
     pkgNameSuffix = 'en.sflix'
     extClass = '.SFlix'
-    extVersionCode = 14
+    extVersionCode = 15
     libVersion = '13'
 }
 

--- a/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlixFilters.kt
+++ b/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/SFlixFilters.kt
@@ -72,6 +72,8 @@ object SFlixFilters {
     )
 
     internal fun getSearchParameters(filters: AnimeFilterList): FilterSearchParams {
+        if (filters.isEmpty()) return FilterSearchParams()
+
         return FilterSearchParams(
             filters.asQueryPart<TypeFilter>(),
             filters.asQueryPart<QualityFilter>(),

--- a/src/en/zoro/build.gradle
+++ b/src/en/zoro/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'zoro.to (experimental)'
     pkgNameSuffix = 'en.zoro'
     extClass = '.Zoro'
-    extVersionCode = 15
+    extVersionCode = 16
     libVersion = '13'
 }
 

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/ZoroFilters.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/ZoroFilters.kt
@@ -78,6 +78,8 @@ object ZoroFilters {
     )
 
     internal fun getSearchParameters(filters: AnimeFilterList): FilterSearchParams {
+        if (filters.isEmpty()) return FilterSearchParams()
+
         val genres: String = filters.filterIsInstance<GenresFilter>()
             .first()
             .state.mapNotNull { format ->

--- a/src/pt/animesvision/build.gradle
+++ b/src/pt/animesvision/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimesVision'
     pkgNameSuffix = 'pt.animesvision'
     extClass = '.AnimesVision'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '13'
 }
 

--- a/src/pt/animesvision/src/eu/kanade/tachiyomi/animeextension/pt/animesvision/AVFilters.kt
+++ b/src/pt/animesvision/src/eu/kanade/tachiyomi/animeextension/pt/animesvision/AVFilters.kt
@@ -69,6 +69,8 @@ object AVFilters {
     )
 
     internal fun getSearchParameters(filters: AnimeFilterList): FilterSearchParams {
+        if (filters.isEmpty()) return FilterSearchParams()
+
         val genres: String = filters.filterIsInstance<GenresFilter>()
             .mapNotNull { filter ->
                 filter.state.mapNotNull { format ->

--- a/src/pt/betteranime/build.gradle
+++ b/src/pt/betteranime/build.gradle
@@ -6,18 +6,8 @@ ext {
     extName = 'Better Anime'
     pkgNameSuffix = 'pt.betteranime'
     extClass = '.BetterAnime'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '13'
-}
-
-dependencies {
-    compileOnly 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2'
-}
-
-android {
-    kotlinOptions {
-        freeCompilerArgs += "-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi"
-    }
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/betteranime/src/eu/kanade/tachiyomi/animeextension/pt/betteranime/BAFilters.kt
+++ b/src/pt/betteranime/src/eu/kanade/tachiyomi/animeextension/pt/betteranime/BAFilters.kt
@@ -50,6 +50,8 @@ object BAFilters {
     )
 
     internal fun getSearchParameters(filters: AnimeFilterList): FilterSearchParams {
+        if (filters.isEmpty()) return FilterSearchParams()
+
         val genres = listOf("") + filters.getFirst<GenresFilter>().state
             .mapNotNull { genre ->
                 if (genre.state) {

--- a/src/pt/sukianimes/src/eu/kanade/tachiyomi/animeextension/pt/sukianimes/SKFilters.kt
+++ b/src/pt/sukianimes/src/eu/kanade/tachiyomi/animeextension/pt/sukianimes/SKFilters.kt
@@ -58,6 +58,9 @@ object SKFilters {
     )
 
     internal fun getSearchParameters(filters: AnimeFilterList): FilterSearchParams {
+
+        if (filters.isEmpty()) return FilterSearchParams()
+
         val genres = filters.getFirst<GenresFilter>().state
             .mapNotNull { genre ->
                 if (genre.state) {

--- a/src/pt/sukianimes/src/eu/kanade/tachiyomi/animeextension/pt/sukianimes/SukiAnimes.kt
+++ b/src/pt/sukianimes/src/eu/kanade/tachiyomi/animeextension/pt/sukianimes/SukiAnimes.kt
@@ -146,12 +146,7 @@ class SukiAnimes : ParsedAnimeHttpSource() {
                 .asObservableSuccess()
                 .map { searchAnimeBySlugParse(it, slug) }
         } else {
-            val params = if (filters.size > 0) {
-                SKFilters.getSearchParameters(filters)
-            } else {
-                // default implementation, prevents "List is empty" error.
-                SKFilters.FilterSearchParams()
-            }
+            val params = SKFilters.getSearchParameters(filters)
             client.newCall(searchAnimeRequest(page, query, params))
                 .asObservableSuccess()
                 .map { searchAnimeParse(it, page) }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio (all of them)

Modified extensions: Zoro.to, SukiAnimes, SFlix, Dopebox, BetterAnime and AnimesVision.

Note: I didn't bump the SukiAnimes version, because I only made a tiny refactor.

The problematic files were found using the following commands:
```bash
$ cd aniyomi-extensions/src
$ grep -R getSearchParameters -l | grep Filters.kt | xargs grep CheckBoxVal -l
```