### PR TITLE
SuperStream: Add third api url

### DIFF
--- a/src/en/superstream/build.gradle
+++ b/src/en/superstream/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'SuperStream'
     pkgNameSuffix = 'en.superstream'
     extClass = '.SuperStream'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '13'
 }
 

--- a/src/en/superstream/src/eu/kanade/tachiyomi/animeextension/en/superstream/DataModel.kt
+++ b/src/en/superstream/src/eu/kanade/tachiyomi/animeextension/en/superstream/DataModel.kt
@@ -170,7 +170,7 @@ data class SeriesData(
     val collect: Int? = null,
     val view: Int? = null,
     val download: Int? = null,
-    val update_time: String? = null,
+    val update_time: JsonElement? = null,
     val released: String? = null,
     val released_timestamp: Int? = null,
     val episode_released: String? = null,

--- a/src/en/superstream/src/eu/kanade/tachiyomi/animeextension/en/superstream/SuperStream.kt
+++ b/src/en/superstream/src/eu/kanade/tachiyomi/animeextension/en/superstream/SuperStream.kt
@@ -137,7 +137,7 @@ class SuperStream : ConfigurableAnimeSource, AnimeHttpSource() {
     override fun searchAnimeParse(response: Response) = throw Exception("not used")
 
     override fun fetchAnimeDetails(anime: SAnime): Observable<SAnime> {
-        val data = superStreamAPI.load(anime.url)
+        val data = superStreamAPI.load(anime.url, true)
         val ani = SAnime.create()
         val (movie, seriesData) = data
         val (detail, _) = seriesData


### PR DESCRIPTION
Move detail fetching to second api url to avoid hammering one api end all the time

Closes #1111
Closes #1106 

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
