### PR TITLE
Fembed extractor updated & LocoPelis updates

### DIFF
--- a/lib/fembed-extractor/src/main/java/eu/kanade/tachiyomi/lib/fembedextractor/FembedExtractor.kt
+++ b/lib/fembed-extractor/src/main/java/eu/kanade/tachiyomi/lib/fembedextractor/FembedExtractor.kt
@@ -1,14 +1,20 @@
 package eu.kanade.tachiyomi.lib.fembedextractor
 
 import eu.kanade.tachiyomi.animesource.model.Video
+import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 
 class FembedExtractor(private val client: OkHttpClient) {
-    fun videosFromUrl(url: String, prefix: String = ""): List<Video> {
-        val videoApi = url.replace("/v/", "/api/source/")
+    fun videosFromUrl(url: String, prefix: String = "", redirect: Boolean = false): List<Video> {
+        val videoApi = if (redirect) {
+            (runCatching { client.newCall(GET(url)).execute().request.url.toString()
+                .replace("/v/", "/api/source/") }.getOrNull() ?: return emptyList<Video>())
+        } else {
+            url.replace("/v/", "/api/source/")
+        }
         val body = runCatching {
             client.newCall(POST(videoApi)).execute().body?.string().orEmpty()
         }.getOrNull() ?: return emptyList<Video>()

--- a/src/es/locopelis/build.gradle
+++ b/src/es/locopelis/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'LocoPelis'
     pkgNameSuffix = 'es.locopelis'
     extClass = '.LocoPelis'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 

--- a/src/es/locopelis/src/eu/kanade/tachiyomi/animeextension/es/locopelis/LocoPelis.kt
+++ b/src/es/locopelis/src/eu/kanade/tachiyomi/animeextension/es/locopelis/LocoPelis.kt
@@ -126,7 +126,7 @@ class LocoPelis : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 embedUrl.contains("diampokusy.com") || embedUrl.contains("i18n.pw") || embedUrl.contains("vanfem.com") ||
                 embedUrl.contains("fembed9hd.com") || embedUrl.contains("votrefilms.xyz") || embedUrl.contains("watchjavnow.xyz")
             ) {
-                val videos = FembedExtractor(client).videosFromUrl(url)
+                val videos = FembedExtractor(client).videosFromUrl(url, redirect = true)
                 videoList.addAll(videos)
             }
             if (url.lowercase().contains("streamtape")) {


### PR DESCRIPTION
- Functionality for the Fembed extractor to redirect to a mirror link and then extract the videos.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
