### PR TITLE
Fix crash on stable

### DIFF
--- a/src/it/aniplay/build.gradle
+++ b/src/it/aniplay/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AniPlay'
     pkgNameSuffix = 'it.aniplay'
     extClass = '.AniPlay'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 

--- a/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlay.kt
+++ b/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlay.kt
@@ -235,7 +235,7 @@ class AniPlay : ConfigurableAnimeSource, AnimeHttpSource() {
                         newUrl = videoUrl.substringBeforeLast("/") + "/" + newUrl
                     }
 
-                    videoList.add(Video(newUrl, quality, newUrl, Headers.headersOf("Referer", "https://aniplay.it/")))
+                    videoList.add(Video(newUrl, quality, newUrl, headers = Headers.headersOf("Referer", "https://aniplay.it/")))
                 }
         } else {}
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Prevents some videos from crashing when running aniyomi stable
