### PR TITLE
UHDMovies: Fix search empty entry and list collection movies as episodes

### DIFF
--- a/src/en/uhdmovies/build.gradle
+++ b/src/en/uhdmovies/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'UHD Movies (Experimental)'
     pkgNameSuffix = 'en.uhdmovies'
     extClass = '.UHDMovies'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
