### PR TITLE
Jellyfin: Rewrite, add support for collection, and preference for metadata grabber

### DIFF
--- a/src/all/jellyfin/build.gradle
+++ b/src/all/jellyfin/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 ext {
     extName = 'Jellyfin'
     pkgNameSuffix = 'all.jellyfin'
     extClass = '.Jellyfin'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '13'
 }
 

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/DataModel.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/DataModel.kt
@@ -1,0 +1,60 @@
+package eu.kanade.tachiyomi.animeextension.all.jellyfin
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ItemsResponse(
+    val TotalRecordCount: Int,
+    val Items: List<Item>
+) {
+    @Serializable
+    data class Item(
+        val Name: String,
+        val Id: String,
+        val Type: String,
+        val LocationType: String,
+        val ImageTags: ImageObject,
+        val IndexNumber: Float? = null,
+        val Genres: List<String>? = null,
+        val Status: String? = null,
+        val SeriesStudio: String? = null,
+        val Overview: String? = null,
+        val SeriesName: String? = null,
+        val SeriesId: String? = null,
+    ) {
+        @Serializable
+        data class ImageObject(
+            val Primary: String? = null
+        )
+    }
+}
+
+@Serializable
+data class SessionResponse(
+    val MediaSources: List<MediaObject>,
+    val PlaySessionId: String,
+) {
+    @Serializable
+    data class MediaObject(
+        val MediaStreams: List<MediaStream>
+    ) {
+        @Serializable
+        data class MediaStream(
+            val Codec: String,
+            val Index: Int,
+            val Type: String,
+            val SupportsExternalStream: Boolean,
+            val Language: String? = null,
+            val DisplayTitle: String? = null,
+            val Height: Int? = null,
+            val Width: Int? = null
+        )
+    }
+}
+
+@Serializable
+data class LinkData(
+    val path: String,
+    val seriesId: String,
+    val seasonId: String,
+)

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -25,10 +25,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Dns
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
@@ -589,15 +585,15 @@ class Jellyfin : ConfigurableAnimeSource, AnimeHttpSource() {
                                 val mediaLibsResponse = client.newCall(
                                     GET("$baseUrl/Users/$userId/Items?api_key=$apiKey")
                                 ).execute()
-                                val mediaJson = mediaLibsResponse.body?.let { Json.decodeFromString<JsonObject>(it.string()) }?.get("Items")?.jsonArray
+                                val mediaJson = mediaLibsResponse.body?.let { json.decodeFromString<ItemsResponse>(it.string()) }?.Items
 
                                 val entriesArray = mutableListOf<String>()
                                 val entriesValueArray = mutableListOf<String>()
 
                                 if (mediaJson != null) {
                                     for (media in mediaJson) {
-                                        entriesArray.add(media.jsonObject["Name"]!!.jsonPrimitive.content)
-                                        entriesValueArray.add(media.jsonObject["Id"]!!.jsonPrimitive.content)
+                                        entriesArray.add(media.Name)
+                                        entriesValueArray.add(media.Id)
                                     }
                                 }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Add support for collections
Add toggle in preference to grab metadata from series instead of seasons
Search can now search through more than one series at a time
