### PR TITLE
UHDMovies: Fallback to index if episode number is not available

### DIFF
--- a/src/en/uhdmovies/build.gradle
+++ b/src/en/uhdmovies/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'UHD Movies'
     pkgNameSuffix = 'en.uhdmovies'
     extClass = '.UHDMovies'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '13'
 }
 

--- a/src/en/uhdmovies/src/eu/kanade/tachiyomi/animeextension/en/uhdmovies/UHDMovies.kt
+++ b/src/en/uhdmovies/src/eu/kanade/tachiyomi/animeextension/en/uhdmovies/UHDMovies.kt
@@ -113,7 +113,8 @@ class UHDMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val episodeElements = resp.select("p:has(a[href*=?id])[style*=center],p:has(a[href*=?id]):has(span.maxbutton-1-center)")
         val qualityRegex = "[0-9]{3,4}p".toRegex(RegexOption.IGNORE_CASE)
         if (episodeElements.first().text().contains("Episode", true) ||
-            episodeElements.first().text().contains("Zip", true)
+            episodeElements.first().text().contains("Zip", true) ||
+            episodeElements.first().text().contains("Pack", true)
         ) {
             episodeElements.map { row ->
                 val prevP = row.previousElementSibling()
@@ -139,14 +140,16 @@ class UHDMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                     !it.text().contains("Zip", true) &&
                         !it.text().contains("Pack", true) &&
                         !it.text().contains("Volume ", true)
-                }.map { linkElement ->
-                    val episode = linkElement.text().replace("Episode", "", true).trim()
+                }.mapIndexed { index, linkElement ->
+                    val episode = linkElement?.text()
+                        ?.replace("Episode", "", true)
+                        ?.trim()?.toFloatOrNull() ?: (index + 1)
                     Triple(
                         season + "_$episode",
-                        linkElement.attr("href")!!,
+                        linkElement.attr("href") ?: return@mapIndexed null,
                         quality
                     )
-                }
+                }.filterNotNull()
             }.flatten().groupBy { it.first }.map { group ->
                 val (season, episode) = group.key.split("_")
                 episodeList.add(

--- a/src/en/uhdmovies/src/eu/kanade/tachiyomi/animeextension/en/uhdmovies/UHDMovies.kt
+++ b/src/en/uhdmovies/src/eu/kanade/tachiyomi/animeextension/en/uhdmovies/UHDMovies.kt
@@ -143,7 +143,7 @@ class UHDMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 }.mapIndexed { index, linkElement ->
                     val episode = linkElement?.text()
                         ?.replace("Episode", "", true)
-                        ?.trim()?.toFloatOrNull() ?: (index + 1)
+                        ?.trim()?.toIntOrNull() ?: (index + 1)
                     Triple(
                         season + "_$episode",
                         linkElement.attr("href") ?: return@mapIndexed null,


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
