### PR TITLE
Fallback for adaptive icon extractor

### DIFF
--- a/.github/scripts/create-repo.sh
+++ b/.github/scripts/create-repo.sh
@@ -30,6 +30,9 @@ for APK in ${APKS[@]}; do
     LANG=$(echo $APK | grep -Po "aniyomi-\K[^\.]+")
 
     ICON=$(echo "$BADGING" | grep -Po "application-icon-320.*'\K[^']+")
+    if [[ $ICON == *xml ]]; then
+      ICON="res/jy.png"
+    fi
     unzip -p $APK $ICON > icon/${FILENAME%.*}.png
 
     SOURCE_INFO=$(jq ".[\"$PKGNAME\"]" < ../output.json)


### PR DESCRIPTION
This a generic fix for the icon extractor. it fails to get the icon if extension is using adaptive icons. idk if `res/jy.png` is the name for 320 icon size but every extension I checked that is using adaptive icons have the same names for the png icons. 