### PR TITLE
Changed keys' URL

### DIFF
--- a/src/en/dopebox/build.gradle
+++ b/src/en/dopebox/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'DopeBox'
     pkgNameSuffix = 'en.dopebox'
     extClass = '.DopeBox'
-    extVersionCode = 16
+    extVersionCode = 17
     libVersion = '13'
 }
 

--- a/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/extractors/DopeBoxExtractor.kt
+++ b/src/en/dopebox/src/eu/kanade/tachiyomi/animeextension/en/dopebox/extractors/DopeBoxExtractor.kt
@@ -48,7 +48,7 @@ class DopeBoxExtractor(private val client: OkHttpClient) {
             .execute()
             .body!!.string()
 
-        val key = newClient.newCall(GET("https://raw.githubusercontent.com/consumet/rapidclown/rabbitstream/key.txt"))
+        val key = newClient.newCall(GET("https://raw.githubusercontent.com/enimax-anime/key/e4/key.txt"))
             .execute()
             .body!!.string()
         // encrypted data will start with "U2Fsd..." because they put

--- a/src/en/sflix/build.gradle
+++ b/src/en/sflix/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Sflix'
     pkgNameSuffix = 'en.sflix'
     extClass = '.SFlix'
-    extVersionCode = 15
+    extVersionCode = 16
     libVersion = '13'
 }
 

--- a/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/extractors/SFlixExtractor.kt
+++ b/src/en/sflix/src/eu/kanade/tachiyomi/animeextension/en/sflix/extractors/SFlixExtractor.kt
@@ -48,7 +48,7 @@ class SFlixExtractor(private val client: OkHttpClient) {
             .execute()
             .body!!.string()
 
-        val key = newClient.newCall(GET("https://raw.githubusercontent.com/consumet/rapidclown/rabbitstream/key.txt"))
+        val key = newClient.newCall(GET("https://raw.githubusercontent.com/enimax-anime/key/e4/key.txt"))
             .execute()
             .body!!.string()
 

--- a/src/en/zoro/build.gradle
+++ b/src/en/zoro/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'zoro.to (experimental)'
     pkgNameSuffix = 'en.zoro'
     extClass = '.Zoro'
-    extVersionCode = 19
+    extVersionCode = 20
     libVersion = '13'
 }
 

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/extractors/ZoroExtractor.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/extractors/ZoroExtractor.kt
@@ -37,7 +37,7 @@ class ZoroExtractor(private val client: OkHttpClient) {
             .execute()
             .body!!.string()
 
-        val key = newClient.newCall(GET("https://raw.githubusercontent.com/consumet/rapidclown/main/key.txt"))
+        val key = newClient.newCall(GET("https://raw.githubusercontent.com/enimax-anime/key/e6/key.txt"))
             .execute()
             .body!!.string()
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

https://github.com/consumet/rapidclown isn't actively maintained anymore, since Consumet has switched to https://github.com/enimax-anime/key, which is more reliable than rapidclown.
