### PR TITLE
fix(AnimesUp): Prevent edge-case error on video extractor

### DIFF
--- a/src/pt/animesup/build.gradle
+++ b/src/pt/animesup/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'AnimesUP'
     pkgNameSuffix = 'pt.animesup'
     extClass = '.AnimesUp'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '13'
 }
 

--- a/src/pt/animesup/src/eu/kanade/tachiyomi/animeextension/pt/animesup/AnimesUp.kt
+++ b/src/pt/animesup/src/eu/kanade/tachiyomi/animeextension/pt/animesup/AnimesUp.kt
@@ -32,7 +32,7 @@ class AnimesUp : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "AnimesUp"
 
-    override val baseUrl = "https://animesup.biz"
+    override val baseUrl = "https://animesup.cx"
 
     override val lang = "pt-BR"
 

--- a/src/pt/animesup/src/eu/kanade/tachiyomi/animeextension/pt/animesup/extractors/LegacyFunExtractor.kt
+++ b/src/pt/animesup/src/eu/kanade/tachiyomi/animeextension/pt/animesup/extractors/LegacyFunExtractor.kt
@@ -23,7 +23,7 @@ class LegacyFunExtractor(private val client: OkHttpClient) {
                 if (form == null) {
                     return getVideoFromDocument(body, quality)
                 } else {
-                    val url = form.attr("action").let {
+                    val newUrl = form.attr("action").let {
                         if (!it.startsWith("http"))
                             "https://legacyfun.site/$it"
                         else it
@@ -32,7 +32,7 @@ class LegacyFunExtractor(private val client: OkHttpClient) {
                     val formBody = FormBody.Builder().apply {
                         add("token", token)
                     }.build()
-                    body = client.newCall(POST(url, body = formBody))
+                    body = client.newCall(POST(newUrl, body = formBody))
                         .execute()
                         .asJsoup()
                 }
@@ -40,10 +40,10 @@ class LegacyFunExtractor(private val client: OkHttpClient) {
         }
     }
 
-    private fun getVideoFromDocument(doc: Document, quality: String): Video? {
-        val iframeUrl = doc.selectFirst("iframe#iframeidv").attr("src")
+    private fun getVideoFromDocument(document: Document, quality: String): Video? {
+        val iframeUrl = document.selectFirst("iframe#iframeidv")!!.attr("src")
         val newHeaders = Headers.headersOf(
-            "referer", doc.location(),
+            "referer", document.location(),
             "user-agent", USER_AGENT
         )
         val newDoc = client.newCall(GET(iframeUrl, newHeaders)).execute().asJsoup()

--- a/src/pt/animesup/src/eu/kanade/tachiyomi/animeextension/pt/animesup/extractors/LegacyFunExtractor.kt
+++ b/src/pt/animesup/src/eu/kanade/tachiyomi/animeextension/pt/animesup/extractors/LegacyFunExtractor.kt
@@ -53,8 +53,8 @@ class LegacyFunExtractor(private val client: OkHttpClient) {
             } ?: doc.selectFirst("script:containsData(var player)")?.data()
         }
         return body?.let {
-            val url = it.substringAfter("file\":")
-                .substringAfter("\"")
+            val url = "https" + it.substringAfter("file:")
+                .substringAfter("\"https")
                 .substringBefore("\"")
             val videoHeaders = Headers.headersOf(
                 "referer", iframeUrl,


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
