### PR TITLE
AnimePahe: Fix lags and reduce DDoS to the server

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimePahe'
     pkgNameSuffix = 'en.animepahe'
     extClass = '.AnimePahe'
-    extVersionCode = 20
+    extVersionCode = 21
     libVersion = '13'
 }
 

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -43,7 +43,9 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override val name = "AnimePahe"
 
-    override val baseUrl by lazy { preferences.getString("preferred_domain", "https://animepahe.com")!! }
+    override val baseUrl by lazy {
+        preferences.getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
+    }
 
     override val lang = "en"
 
@@ -219,7 +221,7 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     private fun getVideo(paheUrl: String, kwikUrl: String, quality: String): Video {
-        return if (preferences.getBoolean("preferred_link_type", false)) {
+        return if (preferences.getBoolean(PREF_LINK_TYPE_KEY, PREF_LINK_TYPE_DEFAULT)) {
             val videoUrl = KwikExtractor(client).getHlsStreamUrl(kwikUrl, referer = baseUrl)
             Video(
                 videoUrl,
@@ -234,8 +236,8 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     override fun List<Video>.sort(): List<Video> {
-        val subPreference = preferences.getString("preferred_sub", "jpn")!!
-        val quality = preferences.getString("preferred_quality", "1080")!!
+        val subPreference = preferences.getString(PREF_SUB_KEY, PREF_SUB_DEFAULT)!!
+        val quality = preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!!
         val shouldEndWithEng = (subPreference == "eng")
 
         return this.sortedWith(
@@ -248,11 +250,11 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         val videoQualityPref = ListPreference(screen.context).apply {
-            key = "preferred_quality"
-            title = "Preferred quality"
-            entries = arrayOf("1080p", "720p", "360p")
-            entryValues = arrayOf("1080", "720", "360")
-            setDefaultValue("1080")
+            key = PREF_QUALITY_KEY
+            title = PREF_QUALITY_TITLE
+            entries = PREF_QUALITY_VALUES
+            entryValues = PREF_QUALITY_VALUES
+            setDefaultValue(PREF_QUALITY_DEFAULT)
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -263,11 +265,11 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
             }
         }
         val domainPref = ListPreference(screen.context).apply {
-            key = "preferred_domain"
-            title = "Preferred domain (requires app restart)"
-            entries = arrayOf("animepahe.com", "animepahe.ru", "animepahe.org")
-            entryValues = arrayOf("https://animepahe.com", "https://animepahe.ru", "https://animepahe.org")
-            setDefaultValue("https://animepahe.com")
+            key = PREF_DOMAIN_KEY
+            title = PREF_DOMAIN_TITLE
+            entries = PREF_DOMAIN_ENTRIES
+            entryValues = PREF_DOMAIN_VALUES
+            setDefaultValue(PREF_DOMAIN_DEFAULT)
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -278,11 +280,11 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
             }
         }
         val subPref = ListPreference(screen.context).apply {
-            key = "preferred_sub"
-            title = "Prefer subs or dubs?"
-            entries = arrayOf("sub", "dub")
-            entryValues = arrayOf("jpn", "eng")
-            setDefaultValue("jpn")
+            key = PREF_SUB_KEY
+            title = PREF_SUB_TITLE
+            entries = PREF_SUB_ENTRIES
+            entryValues = PREF_SUB_VALUES
+            setDefaultValue(PREF_SUB_DEFAULT)
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -293,12 +295,10 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
             }
         }
         val linkPref = SwitchPreferenceCompat(screen.context).apply {
-            key = "preferred_link_type"
-            title = "Use HLS links"
-            summary = """Enable this if you are having Cloudflare issues.
-                |Note that this will break the ability to seek inside of the video unless the episode is downloaded in advance.
-            """.trimMargin()
-            setDefaultValue(false)
+            key = PREF_LINK_TYPE_KEY
+            title = PREF_LINK_TYPE_TITLE
+            summary = PREF_LINK_TYPE_SUMMARY
+            setDefaultValue(PREF_LINK_TYPE_DEFAULT)
 
             setOnPreferenceChangeListener { _, newValue ->
                 val new = newValue as Boolean
@@ -309,5 +309,35 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
         screen.addPreference(domainPref)
         screen.addPreference(subPref)
         screen.addPreference(linkPref)
+    }
+
+    companion object {
+        private const val PREF_QUALITY_KEY = "preffered_quality"
+        private const val PREF_QUALITY_TITLE = "Preferred quality"
+        private const val PREF_QUALITY_DEFAULT = "1080p"
+        private val PREF_QUALITY_VALUES = arrayOf("1080p", "720p", "360p")
+
+        private const val PREF_DOMAIN_KEY = "preffered_domain"
+        private const val PREF_DOMAIN_TITLE = "Preferred domain (requires app restart)"
+        private const val PREF_DOMAIN_DEFAULT = "https://animepahe.com"
+        private val PREF_DOMAIN_ENTRIES = arrayOf("animepahe.com", "animepahe.ru", "animepahe.org")
+        private val PREF_DOMAIN_VALUES by lazy {
+            PREF_DOMAIN_ENTRIES.map { "https://" + it }.toTypedArray()
+        }
+
+        private const val PREF_SUB_KEY = "preffered_sub"
+        private const val PREF_SUB_TITLE = "Prefer subs or dubs?"
+        private const val PREF_SUB_DEFAULT = "jpn"
+        private val PREF_SUB_ENTRIES = arrayOf("sub", "dub")
+        private val PREF_SUB_VALUES = arrayOf("jpn", "eng")
+
+        private const val PREF_LINK_TYPE_KEY = "preffered_link_type"
+        private const val PREF_LINK_TYPE_TITLE = "Use HLS links"
+        private const val PREF_LINK_TYPE_DEFAULT = false
+        private val PREF_LINK_TYPE_SUMMARY by lazy {
+            """Enable this if you are having Cloudflare issues.
+            |Note that this will break the ability to seek inside of the video unless the episode is downloaded in advance.
+            """.trimMargin()
+        }
     }
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -13,7 +13,6 @@ import eu.kanade.tachiyomi.animesource.model.SEpisode
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.util.asJsoup
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -27,11 +26,9 @@ import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import rx.Observable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
-import java.lang.Exception
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -49,146 +46,113 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override val lang = "en"
 
-    override val supportsLatest = false
+    override val supportsLatest = true
 
     private val json: Json by injectLazy()
 
     override val client: OkHttpClient = network.cloudflareClient
 
+    // =========================== Anime Details ============================
     override fun animeDetailsParse(response: Response): SAnime {
-        val jsoup = response.asJsoup()
-        val anime = SAnime.create()
-        val animeUrl = response.request.url.toString()
-        anime.setUrlWithoutDomain(animeUrl)
-        anime.title = jsoup.selectFirst("div.title-wrapper > h1 > span")!!.text()
-        anime.author = jsoup.select("div.col-sm-4.anime-info p:contains(Studio:)")
-            .firstOrNull()?.text()?.replace("Studio: ", "")
-        anime.status = parseStatus(jsoup.selectFirst("div.col-sm-4.anime-info p:contains(Status:) a")!!.text())
-        anime.thumbnail_url = jsoup.selectFirst("div.anime-poster a")!!.attr("href")
-        anime.genre = jsoup.select("div.anime-genre ul li").joinToString { it.text() }
-        val synonyms = jsoup.select("div.col-sm-4.anime-info p:contains(Synonyms:)")
-            .firstOrNull()?.text()
-        anime.description = jsoup.select("div.anime-summary").text() +
-            if (synonyms.isNullOrEmpty()) "" else "\n\n$synonyms"
-        return anime
-    }
-
-    override fun latestUpdatesRequest(page: Int) = throw Exception("not supported")
-
-    override fun latestUpdatesParse(response: Response) = throw Exception("not supported")
-
-    override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request =
-        GET("$baseUrl/api?m=search&l=8&q=$query")
-
-    override fun searchAnimeParse(response: Response): AnimesPage {
-        val responseString = response.body.string()
-        return parseSearchJson(responseString)
-    }
-
-    private fun parseSearchJson(jsonLine: String?): AnimesPage {
-        val jsonData = jsonLine ?: return AnimesPage(emptyList(), false)
-        val jObject = json.decodeFromString<JsonObject>(jsonData)
-        val data = jObject["data"] ?: return AnimesPage(emptyList(), false)
-        val array = data.jsonArray
-        val animeList = mutableListOf<SAnime>()
-        for (item in array) {
-            val anime = SAnime.create()
-            anime.title = item.jsonObject["title"]!!.jsonPrimitive.content
-            anime.thumbnail_url = item.jsonObject["poster"]!!.jsonPrimitive.content
-            val animeId = item.jsonObject["id"]!!.jsonPrimitive.int
-            val session = item.jsonObject["session"]!!.jsonPrimitive.content
-
-            anime.setUrlWithoutDomain("$baseUrl/anime/$session?anime_id=$animeId")
-            animeList.add(anime)
+        val document = response.use { it.asJsoup() }
+        return SAnime.create().apply {
+            val animeUrl = response.request.url.toString()
+            setUrlWithoutDomain(animeUrl)
+            title = document.selectFirst("div.title-wrapper > h1 > span")!!.text()
+            author = document.selectFirst("div.col-sm-4.anime-info p:contains(Studio:)")
+                ?.text()
+                ?.replace("Studio: ", "")
+            status = parseStatus(document.selectFirst("div.col-sm-4.anime-info p:contains(Status:) a")!!.text())
+            thumbnail_url = document.selectFirst("div.anime-poster a")!!.attr("href")
+            genre = document.select("div.anime-genre ul li").joinToString { it.text() }
+            val synonyms = document.selectFirst("div.col-sm-4.anime-info p:contains(Synonyms:)")
+                ?.text()
+            description = document.select("div.anime-summary").text() +
+                if (synonyms.isNullOrEmpty()) "" else "\n\n$synonyms"
         }
-        return AnimesPage(animeList, false)
     }
 
-    override fun popularAnimeRequest(page: Int): Request = GET("$baseUrl/api?m=airing&page=$page")
+    // =============================== Latest ===============================
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/api?m=airing&page=$page")
 
-    override fun popularAnimeParse(response: Response): AnimesPage {
-        val responseString = response.body.string()
-        return parsePopularAnimeJson(responseString)
-    }
-
-    private fun parsePopularAnimeJson(jsonLine: String?): AnimesPage {
-        val jsonData = jsonLine ?: return AnimesPage(emptyList(), false)
-        val jObject = json.decodeFromString<JsonObject>(jsonData)
+    override fun latestUpdatesParse(response: Response): AnimesPage {
+        val responseString = response.use { it.body.string() }
+        val jObject = json.decodeFromString<JsonObject>(responseString)
         val lastPage = jObject["last_page"]!!.jsonPrimitive.int
         val page = jObject["current_page"]!!.jsonPrimitive.int
         val hasNextPage = page < lastPage
-        val array = jObject["data"]!!.jsonArray
-        val animeList = mutableListOf<SAnime>()
-        for (item in array) {
-            val anime = SAnime.create()
-            anime.title = item.jsonObject["anime_title"]!!.jsonPrimitive.content
-            anime.thumbnail_url = item.jsonObject["snapshot"]!!.jsonPrimitive.content
-            val animeId = item.jsonObject["anime_id"]!!.jsonPrimitive.int
-            val session = item.jsonObject["anime_session"]!!.jsonPrimitive.content
-
-            anime.setUrlWithoutDomain("$baseUrl/anime/$session?anime_id=$animeId")
-            anime.artist = item.jsonObject["fansub"]!!.jsonPrimitive.content
-            animeList.add(anime)
+        val animeList = jObject["data"]!!.jsonArray.map { item ->
+            val itemObj = item.jsonObject
+            SAnime.create().apply {
+                title = itemObj["anime_title"]!!.jsonPrimitive.content
+                thumbnail_url = itemObj["snapshot"]!!.jsonPrimitive.content
+                val animeId = itemObj["anime_id"]!!.jsonPrimitive.int
+                val session = itemObj["anime_session"]!!.jsonPrimitive.content
+                setUrlWithoutDomain("$baseUrl/anime/$session?anime_id=$animeId")
+                artist = itemObj["fansub"]!!.jsonPrimitive.content
+            }
         }
         return AnimesPage(animeList, hasNextPage)
     }
 
-    private fun parseStatus(statusString: String): Int {
-        return when (statusString) {
-            "Currently Airing" -> SAnime.ONGOING
-            "Finished Airing" -> SAnime.COMPLETED
-            else -> SAnime.UNKNOWN
+    // =============================== Search ===============================
+    override fun searchAnimeRequest(page: Int, query: String, filters: AnimeFilterList): Request =
+        GET("$baseUrl/api?m=search&l=8&q=$query")
+
+    override fun searchAnimeParse(response: Response): AnimesPage {
+        val responseString = response.use { it.body.string() }
+        val jObject = json.decodeFromString<JsonObject>(responseString)
+        val data = jObject["data"] ?: return AnimesPage(emptyList(), false)
+        val animeList = data.jsonArray.map { item ->
+            val itemObj = item.jsonObject
+            SAnime.create().apply {
+                title = itemObj["title"]!!.jsonPrimitive.content
+                thumbnail_url = itemObj["poster"]!!.jsonPrimitive.content
+                val animeId = itemObj["id"]!!.jsonPrimitive.int
+                val session = itemObj["session"]!!.jsonPrimitive.content
+                setUrlWithoutDomain("$baseUrl/anime/$session?anime_id=$animeId")
+            }
         }
+        return AnimesPage(animeList, false)
     }
 
-    override fun fetchEpisodeList(anime: SAnime): Observable<List<SEpisode>> {
-        val session = anime.url.substringBefore("?anime_id=").substringAfterLast("/")
+    // ============================== Popular ===============================
+    // This source doesnt have a popular animes page,
+    // so we use latest animes page instead.
+    override fun fetchPopularAnime(page: Int) = fetchLatestUpdates(page)
+    override fun popularAnimeParse(response: Response): AnimesPage = TODO()
+    override fun popularAnimeRequest(page: Int): Request = TODO()
 
-        return if (anime.status != SAnime.LICENSED) {
-            client.newCall(episodeListRequest(anime))
-                .asObservableSuccess()
-                .map { response ->
-                    episodeListParse(response, session)
-                }
-        } else {
-            Observable.error(Exception("Licensed - No episodes to show"))
-        }
-    }
-
+    // ============================== Episodes ==============================
     override fun episodeListRequest(anime: SAnime): Request {
         val session = anime.url.substringBefore("?anime_id=").substringAfterLast("/")
         return GET("$baseUrl/api?m=release&id=$session&sort=episode_desc&page=1")
     }
 
-    override fun episodeListParse(response: Response): List<SEpisode> = throw Exception("Not used")
-
-    private fun episodeListParse(response: Response, animeSession: String): List<SEpisode> {
-        return recursivePages(response, animeSession)
+    override fun episodeListParse(response: Response): List<SEpisode> {
+        val url = response.request.url.toString()
+        val session = url.substringAfter("&id=").substringBefore("&")
+        return recursivePages(response, session)
     }
 
-    private fun parseEpisodePage(jsonLine: String?, animeSession: String): MutableList<SEpisode> {
-        val jsonData = jsonLine ?: return mutableListOf()
-        val jObject = json.decodeFromString<JsonObject>(jsonData)
-        val array = jObject["data"]!!.jsonArray
-        val episodeList = mutableListOf<SEpisode>()
-        for (item in array) {
-            val itemO = item.jsonObject
-            val episode = SEpisode.create()
-            episode.date_upload = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
-                .parse(itemO["created_at"]!!.jsonPrimitive.content)!!.time
-            val session = itemO["session"]!!.jsonPrimitive.content
-            episode.setUrlWithoutDomain("$baseUrl/play/$animeSession/$session")
-            val epNum = itemO["episode"]!!.jsonPrimitive.float
-            episode.episode_number = epNum
-            val epNumString = if (epNum % 1F == 0F) epNum.toInt().toString() else epNum.toString()
-            episode.name = "Episode $epNumString"
-            episodeList.add(episode)
-        }
-        return episodeList
+    private fun parseEpisodePage(jsonLine: String, animeSession: String): MutableList<SEpisode> {
+        val jObject = json.decodeFromString<JsonObject>(jsonLine)
+        return jObject["data"]!!.jsonArray.map { item ->
+            val itemObj = item.jsonObject
+            SEpisode.create().apply {
+                date_upload = itemObj["created_at"]!!.jsonPrimitive.content.toDate()
+                val session = itemObj["session"]!!.jsonPrimitive.content
+                setUrlWithoutDomain("$baseUrl/play/$animeSession/$session")
+                val epNum = itemObj["episode"]!!.jsonPrimitive.float
+                episode_number = epNum
+                val epNumString = if (epNum % 1F == 0F) epNum.toInt().toString() else epNum.toString()
+                name = "Episode $epNumString"
+            }
+        }.toMutableList()
     }
 
     private fun recursivePages(response: Response, animeSession: String): List<SEpisode> {
-        val responseString = response.body.string()
+        val responseString = response.use { it.body.string() }
         val jObject = json.decodeFromString<JsonObject>(responseString)
         val lastPage = jObject["last_page"]!!.jsonPrimitive.int
         val page = jObject["current_page"]!!.jsonPrimitive.int
@@ -206,18 +170,16 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
         return client.newCall(request).execute()
     }
 
+    // ============================ Video Links =============================
     override fun videoListParse(response: Response): List<Video> {
-        val document = response.asJsoup()
-        val videoList = mutableListOf<Video>()
-
-        document.select("div#resolutionMenu > button").forEachIndexed { index, btn ->
+        val document = response.use { it.asJsoup() }
+        val downloadLinks = document.select("div#pickDownload > a")
+        return document.select("div#resolutionMenu > button").mapIndexed { index, btn ->
             val kwikLink = btn.attr("data-src")
             val quality = btn.text()
-            val paheWinLink = document.select("div#pickDownload > a")[index].attr("href")
-            videoList.add(getVideo(paheWinLink, kwikLink, quality))
+            val paheWinLink = downloadLinks[index].attr("href")
+            getVideo(paheWinLink, kwikLink, quality)
         }
-
-        return videoList
     }
 
     private fun getVideo(paheUrl: String, kwikUrl: String, quality: String): Video {
@@ -248,6 +210,7 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
         ).reversed()
     }
 
+    // ============================== Settings ==============================
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         val videoQualityPref = ListPreference(screen.context).apply {
             key = PREF_QUALITY_KEY
@@ -311,7 +274,26 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
         screen.addPreference(linkPref)
     }
 
+    // ============================= Utilities ==============================
+    private fun parseStatus(statusString: String): Int {
+        return when (statusString) {
+            "Currently Airing" -> SAnime.ONGOING
+            "Finished Airing" -> SAnime.COMPLETED
+            else -> SAnime.UNKNOWN
+        }
+    }
+
+    private fun String.toDate(): Long {
+        return runCatching {
+            DATE_FORMATTER.parse(this)?.time ?: 0L
+        }.getOrNull() ?: 0L
+    }
+
     companion object {
+        private val DATE_FORMATTER by lazy {
+            SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
+        }
+
         private const val PREF_QUALITY_KEY = "preffered_quality"
         private const val PREF_QUALITY_TITLE = "Preferred quality"
         private const val PREF_QUALITY_DEFAULT = "1080p"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -120,9 +120,7 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
         for (item in array) {
             val anime = SAnime.create()
             anime.title = item.jsonObject["anime_title"]!!.jsonPrimitive.content
-            if (preferences.getBoolean("preferred_cover_type", false)) {
-                anime.thumbnail_url = item.jsonObject["snapshot"]!!.jsonPrimitive.content
-            }
+            anime.thumbnail_url = item.jsonObject["snapshot"]!!.jsonPrimitive.content
             val animeId = item.jsonObject["anime_id"]!!.jsonPrimitive.int
             val session = item.jsonObject["anime_session"]!!.jsonPrimitive.content
 
@@ -307,23 +305,9 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
                 preferences.edit().putBoolean(key, new).commit()
             }
         }
-        val snapshotPref = SwitchPreferenceCompat(screen.context).apply {
-            key = "preferred_cover_type"
-            title = "Use Snapshot as Cover"
-            summary = """Enable this if you are experiencing lag loading pages.
-                |To get real cover click on the anime to fetch the details
-            """.trimMargin()
-            setDefaultValue(true)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val new = newValue as Boolean
-                preferences.edit().putBoolean(key, new).commit()
-            }
-        }
         screen.addPreference(videoQualityPref)
         screen.addPreference(domainPref)
         screen.addPreference(subPref)
         screen.addPreference(linkPref)
-        screen.addPreference(snapshotPref)
     }
 }

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/dto/AnimePaheDto.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/dto/AnimePaheDto.kt
@@ -1,0 +1,45 @@
+package eu.kanade.tachiyomi.animeextension.en.animepahe.dto
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseDto<T>(
+    @SerialName("current_page")
+    val currentPage: Int,
+    @SerialName("last_page")
+    val lastPage: Int,
+    @EncodeDefault
+    @SerialName("data")
+    val items: List<T> = emptyList(),
+)
+
+@Serializable
+data class LatestAnimeDto(
+    @SerialName("anime_title")
+    val title: String,
+    val snapshot: String,
+    @SerialName("anime_id")
+    val id: Int,
+    @SerialName("anime_session")
+    val animeSession: String,
+    val fansub: String,
+)
+
+@Serializable
+data class SearchResultDto(
+    val title: String,
+    val poster: String,
+    val id: Int,
+    val session: String,
+)
+
+@Serializable
+data class EpisodeDto(
+    @SerialName("created_at")
+    val createdAt: String,
+    val session: String,
+    @SerialName("episode")
+    val episodeNumber: Int,
+)


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio

The problem that was causing the lags on the popular anime page was the fact that the extension was going crazy and sending almost endless requests, even when you just opened it without scrolling down.

<details>
<summary>Http logs of the extension before</summary>

OBS: it kept growing up
![Screenshot_20230313_230756](https://user-images.githubusercontent.com/63046606/224892855-a22c0d70-de71-4883-add0-e849bad19476.png)

</details>

<details>
<summary>Http logs of the extension now</summary>

![Screenshot_20230313_231058](https://user-images.githubusercontent.com/63046606/224892986-c844ccde-3007-43f1-9bac-0af55d0442b1.png)
</details>