### PR TITLE
AnimePahe: Fix broken library URLs

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimePahe'
     pkgNameSuffix = 'en.animepahe'
     extClass = '.AnimePahe'
-    extVersionCode = 21
+    extVersionCode = 22
     libVersion = '13'
 }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio

I forgot to add support to the old anime URLs (that don't have the sessionId in them), so the last update i sent broke lots of things xD