### PR TITLE
Yomiroll: Added second preference locale set to `en-US`

### DIFF
--- a/src/all/kamyroll/build.gradle
+++ b/src/all/kamyroll/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Yomiroll'
     pkgNameSuffix = 'all.kamyroll'
     extClass = '.Yomiroll'
-    extVersionCode = 19
+    extVersionCode = 20
     libVersion = '13'
 }
 

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/Yomiroll.kt
@@ -465,6 +465,7 @@ class Yomiroll : ConfigurableAnimeSource, AnimeHttpSource() {
                 { it.quality.contains("Aud: ${dubLocale.getLocale()}") },
                 { it.quality.contains("HardSub") == shouldContainHard },
                 { it.quality.contains(subLocale) },
+                { it.quality.contains("en-US") },
             ),
         ).reversed()
     }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Basically adds another comparison and puts `en-US` locale at the top if prefered subs locale is missing. Without this fix, aniyomi would pick the first sub according to `videoList` which more often than not isn't English or a second best choice
