### PR TITLE
JeanYves: Fix episodes not loading and add fix for animes without episodes

### DIFF
--- a/src/fr/jeanyves/build.gradle
+++ b/src/fr/jeanyves/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'JeanYves'
     pkgNameSuffix = 'fr.jeanyves'
     extClass = '.JeanYves'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Before, it loaded all 11,000+ episodes on the website in a single anime if an anime path didn't exist. Oops
