### PR TITLE
Add filler markings

### DIFF
--- a/src/en/animedao/build.gradle
+++ b/src/en/animedao/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimeDao'
     pkgNameSuffix = 'en.animedao'
     extClass = '.AnimeDao'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '13'
 }
 

--- a/src/en/animedao/src/eu/kanade/tachiyomi/animeextension/en/animedao/AnimeDao.kt
+++ b/src/en/animedao/src/eu/kanade/tachiyomi/animeextension/en/animedao/AnimeDao.kt
@@ -222,6 +222,9 @@ class AnimeDao : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             episode_number = if (episodeName.contains("Episode ", true)) {
                 episodeName.substringAfter("Episode ").substringBefore(" ").toFloatOrNull() ?: 0F
             } else { 0F }
+            if (element.selectFirst("span.filler") != null && preferences.getBoolean("mark_fillers", true)) {
+                scanlator = "Filler Episode"
+            }
             date_upload = element.selectFirst("span.date")?.let { parseDate(it.text()) } ?: 0L
             setUrlWithoutDomain(element.selectFirst("a[href]")!!.attr("href"))
         }
@@ -403,10 +406,19 @@ class AnimeDao : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 preferences.edit().putBoolean(key, new).commit()
             }
         }
+        val markFillers = SwitchPreferenceCompat(screen.context).apply {
+            key = "mark_fillers"
+            title = "Mark filler episodes"
+            setDefaultValue(true)
+            setOnPreferenceChangeListener { _, newValue ->
+                preferences.edit().putBoolean(key, newValue as Boolean).commit()
+            }
+        }
 
         screen.addPreference(domainPref)
         screen.addPreference(videoQualityPref)
         screen.addPreference(videoServerPref)
         screen.addPreference(episodeSortPref)
+        screen.addPreference(markFillers)
     }
 }

--- a/src/en/nineanime/build.gradle
+++ b/src/en/nineanime/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = '9anime'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.NineAnime'
-    extVersionCode = 41
+    extVersionCode = 42
     libVersion = '13'
 }
 

--- a/src/en/zoro/build.gradle
+++ b/src/en/zoro/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'zoro.to (experimental)'
     pkgNameSuffix = 'en.zoro'
     extClass = '.Zoro'
-    extVersionCode = 27
+    extVersionCode = 28
     libVersion = '13'
 }
 

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/Zoro.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/Zoro.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.SharedPreferences
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.animeextension.en.zoro.extractors.ZoroExtractor
 import eu.kanade.tachiyomi.animeextension.en.zoro.utils.JSONUtil
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
@@ -94,6 +95,9 @@ class Zoro : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 episode_number = it.attr("data-number").toFloat()
                 name = "Episode ${it.attr("data-number")}: ${it.attr("title")}"
                 url = it.attr("href")
+                if (it.hasClass("ssl-item-filler") && preferences.getBoolean(MARK_FILLERS_KEY, MARK_FILLERS_DEFAULT)) {
+                    scanlator = "Filler Episode"
+                }
             }
         }
         return episodeList.reversed()
@@ -386,10 +390,21 @@ class Zoro : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 preferences.edit().putString(key, entry).commit()
             }
         }
+
+        val markFillers = SwitchPreferenceCompat(screen.context).apply {
+            key = MARK_FILLERS_KEY
+            title = MARK_FILLERS_TITLE
+            setDefaultValue(MARK_FILLERS_DEFAULT)
+            setOnPreferenceChangeListener { _, newValue ->
+                preferences.edit().putBoolean(key, newValue as Boolean).commit()
+            }
+        }
+
         screen.addPreference(domainPref)
         screen.addPreference(videoQualityPref)
         screen.addPreference(epTypePref)
         screen.addPreference(subLangPref)
+        screen.addPreference(markFillers)
     }
 
     // ============================= Utilities ==============================
@@ -457,5 +472,9 @@ class Zoro : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             "Japanese",
             "Russian",
         )
+
+        private const val MARK_FILLERS_KEY = "mark_fillers"
+        private const val MARK_FILLERS_TITLE = "Mark filler episodes"
+        private const val MARK_FILLERS_DEFAULT = true
     }
 }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Add filler markings for animedao, 9anime, and zoro