### PR TITLE
fix: Fix filters that refuse to reset

### DIFF
--- a/multisrc/overrides/dooplay/animeonlineninja/src/AnimeOnlineNinjaFilters.kt
+++ b/multisrc/overrides/dooplay/animeonlineninja/src/AnimeOnlineNinjaFilters.kt
@@ -49,7 +49,7 @@ object AnimeOnlineNinjaFilters {
         return state.first { it is R }.toUriPart()
     }
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         InvertedResultsFilter(),
         TypeFilter(),
         LetterFilter(),

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dooplay/DooPlayGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dooplay/DooPlayGenerator.kt
@@ -12,7 +12,7 @@ class DooPlayGenerator : ThemeSourceGenerator {
 
     override val sources = listOf(
         SingleLang("AnimeOnline360", "https://animeonline360.me", "en", isNsfw = false),
-        SingleLang("AnimeOnline.Ninja", "https://www1.animeonline.ninja", "es", className = "AnimeOnlineNinja", isNsfw = false, overrideVersionCode = 26),
+        SingleLang("AnimeOnline.Ninja", "https://www1.animeonline.ninja", "es", className = "AnimeOnlineNinja", isNsfw = false, overrideVersionCode = 27),
         SingleLang("AnimePlayer", "https://animeplayer.com.br", "pt-BR", isNsfw = true),
         SingleLang("AnimesFox BR", "https://animesfoxbr.com", "pt-BR", isNsfw = false, overrideVersionCode = 1),
         SingleLang("Animes Grátis", "https://animesgratis.org", "pt-BR", className = "AnimesGratis", isNsfw = false),

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlixFilters.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlixFilters.kt
@@ -59,7 +59,7 @@ object DopeFlixFilters {
         DopeFlixFiltersData.COUNTRIES.map { CheckBoxVal(it.first, false) },
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         TypeFilter(),
         QualityFilter(),
         ReleaseYearFilter(),

--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlixGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/dopeflix/DopeFlixGenerator.kt
@@ -8,7 +8,7 @@ class DopeFlixGenerator : ThemeSourceGenerator {
 
     override val themeClass = "DopeFlix"
 
-    override val baseVersionCode = 16
+    override val baseVersionCode = 17
 
     override val sources = listOf(
         SingleLang("DopeBox", "https://dopebox.to", "en", isNsfw = false, overrideVersionCode = 1),

--- a/src/all/kamyroll/build.gradle
+++ b/src/all/kamyroll/build.gradle
@@ -8,7 +8,7 @@ ext {
     extName = 'Yomiroll'
     pkgNameSuffix = 'all.kamyroll'
     extClass = '.Yomiroll'
-    extVersionCode = 23
+    extVersionCode = 24
     libVersion = '13'
 }
 

--- a/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/YomirollFilters.kt
+++ b/src/all/kamyroll/src/eu/kanade/tachiyomi/animeextension/all/kamyroll/YomirollFilters.kt
@@ -50,7 +50,7 @@ object YomirollFilters {
         CrunchyFiltersData.LANGUAGE.map { CheckBoxVal(it.first, false) },
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         AnimeFilter.Header("Search Filter (ignored if browsing)"),
         TypeFilter(),
         AnimeFilter.Separator(),

--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AllAnime'
     pkgNameSuffix = 'en.allanime'
     extClass = '.AllAnime'
-    extVersionCode = 21
+    extVersionCode = 22
     libVersion = '13'
 }
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnimeFilters.kt
@@ -61,7 +61,7 @@ object AllAnimeFilters {
         AllAnimeFiltersData.GENRES.map { CheckBoxVal(it.first, false) },
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         OriginFilter(),
         SeasonFilter(),
         ReleaseYearFilter(),

--- a/src/en/animedao/build.gradle
+++ b/src/en/animedao/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimeDao'
     pkgNameSuffix = 'en.animedao'
     extClass = '.AnimeDao'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '13'
 }
 

--- a/src/en/animedao/src/eu/kanade/tachiyomi/animeextension/en/animedao/AnimeDaoFilters.kt
+++ b/src/en/animedao/src/eu/kanade/tachiyomi/animeextension/en/animedao/AnimeDaoFilters.kt
@@ -76,7 +76,7 @@ object AnimeDaoFilters {
 
     class OrderFilter : QueryPartFilter("Order", AnimeDaoFiltersData.ORDER)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         GenreFilter(),
         RatingFilter(),
         LetterFilter(),

--- a/src/en/fmovies/build.gradle
+++ b/src/en/fmovies/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'FMovies'
     pkgNameSuffix = 'en.fmovies'
     extClass = '.FMovies'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '13'
 }
 

--- a/src/en/fmovies/src/eu/kanade/tachiyomi/animeextension/en/fmovies/FMoviesFilters.kt
+++ b/src/en/fmovies/src/eu/kanade/tachiyomi/animeextension/en/fmovies/FMoviesFilters.kt
@@ -103,7 +103,7 @@ object FMoviesFilters {
 
     class SortFilter : QueryPartFilter("Sort", FMoviesFiltersData.SORT)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         TypesFilter(),
         GenresFilter(),
         CountriesFilter(),

--- a/src/en/kawaiifu/build.gradle
+++ b/src/en/kawaiifu/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Kawaiifu'
     pkgNameSuffix = 'en.kawaiifu'
     extClass = '.Kawaiifu'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/en/kawaiifu/src/eu/kanade/tachiyomi/animeextension/en/kawaiifu/KawaiifuFilters.kt
+++ b/src/en/kawaiifu/src/eu/kanade/tachiyomi/animeextension/en/kawaiifu/KawaiifuFilters.kt
@@ -51,7 +51,7 @@ object KawaiifuFilters {
         KawaiifuFiltersData.TAGS.map { CheckBoxVal(it.first, false) },
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         TagsFilter(),
         AnimeFilter.Separator(),
         CategoryFilter(),

--- a/src/en/kickassanime/build.gradle
+++ b/src/en/kickassanime/build.gradle
@@ -9,7 +9,7 @@ ext {
     pkgNameSuffix = 'en.kickassanime'
     extClass = '.KickAssAnime'
     libVersion = '13'
-    extVersionCode = 27
+    extVersionCode = 28
 }
 
 dependencies {

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnimeFilters.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnimeFilters.kt
@@ -33,7 +33,7 @@ object KickAssAnimeFilters {
     class TypeFilter : QueryPartFilter("Type", KickAssAnimeFiltersData.TYPE)
     class SubPageFilter : QueryPartFilter("Sub-page", KickAssAnimeFiltersData.SUBPAGE)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         GenreFilter(),
         YearFilter(),
         StatusFilter(),

--- a/src/en/kissanime/build.gradle
+++ b/src/en/kissanime/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'KissAnime'
     pkgNameSuffix = 'en.kissanime'
     extClass = '.KissAnime'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '13'
 }
 

--- a/src/en/kissanime/src/eu/kanade/tachiyomi/animeextension/en/kissanime/KissAnimeFilters.kt
+++ b/src/en/kissanime/src/eu/kanade/tachiyomi/animeextension/en/kissanime/KissAnimeFilters.kt
@@ -34,7 +34,7 @@ object KissAnimeFilters {
 
     class ScheduleFilter : QueryPartFilter("Schedule", KissAnimeFiltersData.SCHEDULE)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         StatusFilter(),
         GenreFilter(),
         AnimeFilter.Separator(),

--- a/src/en/marinmoe/build.gradle
+++ b/src/en/marinmoe/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'marin.moe'
     pkgNameSuffix = 'en.marinmoe'
     extClass = '.MarinMoe'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '13'
 }
 

--- a/src/en/marinmoe/src/eu/kanade/tachiyomi/animeextension/en/marinmoe/MarinMoeFilters.kt
+++ b/src/en/marinmoe/src/eu/kanade/tachiyomi/animeextension/en/marinmoe/MarinMoeFilters.kt
@@ -54,7 +54,7 @@ object MarinMoeFilters {
 
     class StudioFilter : QueryPartFilter("Studio", MarinMoeFiltersData.STUDIOS)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         SortFilter(),
         AnimeFilter.Separator(),
         TypeFilter(),

--- a/src/en/nineanime/build.gradle
+++ b/src/en/nineanime/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = '9anime'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.NineAnime'
-    extVersionCode = 42
+    extVersionCode = 43
     libVersion = '13'
 }
 

--- a/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnimeFilters.kt
+++ b/src/en/nineanime/src/eu/kanade/tachiyomi/animeextension/en/nineanime/NineAnimeFilters.kt
@@ -89,7 +89,7 @@ object NineAnimeFilters {
         NineAnimeFiltersData.RATING.map { CheckBoxVal(it.first, false) },
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         SortFilter(),
         AnimeFilter.Separator(),
         GenreFilter(),

--- a/src/en/zoro/build.gradle
+++ b/src/en/zoro/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'zoro.to (experimental)'
     pkgNameSuffix = 'en.zoro'
     extClass = '.Zoro'
-    extVersionCode = 28
+    extVersionCode = 29
     libVersion = '13'
 }
 

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/ZoroFilters.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/ZoroFilters.kt
@@ -45,7 +45,7 @@ object ZoroFilters {
         ZoroFiltersData.GENRES.map { CheckBoxVal(it.first, false) },
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         TypeFilter(),
         StatusFilter(),
         RatedFilter(),

--- a/src/it/animeunity/build.gradle
+++ b/src/it/animeunity/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimeUnity'
     pkgNameSuffix = 'it.animeunity'
     extClass = '.AnimeUnity'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '13'
 }
 

--- a/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnityFilters.kt
+++ b/src/it/animeunity/src/eu/kanade/tachiyomi/animeextension/it/animeunity/AnimeUnityFilters.kt
@@ -43,7 +43,7 @@ object AnimeUnityFilters {
 
     class DubFilter : QueryPartFilter("Dub ITA", AnimeUnityFiltersData.DUB)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         AnimeFilter.Header("Le migliori pagine di anime"),
         AnimeFilter.Header("Nota: ignora altri filtri"),
         TopFilter(),

--- a/src/it/aniplay/build.gradle
+++ b/src/it/aniplay/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AniPlay'
     pkgNameSuffix = 'it.aniplay'
     extClass = '.AniPlay'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '13'
 }
 

--- a/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlayFilters.kt
+++ b/src/it/aniplay/src/eu/kanade/tachiyomi/animeextension/it/aniplay/AniPlayFilters.kt
@@ -56,7 +56,7 @@ object AniPlayFilters {
     class AnniFilter : QueryPartFilter("Anni", AniPlayFiltersData.ANNI)
     class StagioneFilter : QueryPartFilter("Stagione", AniPlayFiltersData.STAGIONE)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         OrdinaFilter(),
         AnimeFilter.Separator(),
 

--- a/src/pt/animefire/build.gradle
+++ b/src/pt/animefire/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Anime Fire'
     pkgNameSuffix = 'pt.animefire'
     extClass = '.AnimeFire'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '13'
 }
 

--- a/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/AFFilters.kt
+++ b/src/pt/animefire/src/eu/kanade/tachiyomi/animeextension/pt/animefire/AFFilters.kt
@@ -24,7 +24,7 @@ object AFFilters {
     class GenreFilter : QueryPartFilter("Gênero", AFFiltersData.GENRES)
     class SeasonFilter : QueryPartFilter("Temporada", AFFiltersData.SEASONS)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         AnimeFilter.Header(AFFiltersData.IGNORE_SEARCH_MSG),
         SeasonFilter(),
         AnimeFilter.Header(AFFiltersData.IGNORE_SEASON_MSG),

--- a/src/pt/animesaria/build.gradle
+++ b/src/pt/animesaria/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Animes Aria'
     pkgNameSuffix = 'pt.animesaria'
     extClass = '.AnimesAria'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animesaria/src/eu/kanade/tachiyomi/animeextension/pt/animesaria/AnimesAriaFilters.kt
+++ b/src/pt/animesaria/src/eu/kanade/tachiyomi/animeextension/pt/animesaria/AnimesAriaFilters.kt
@@ -29,7 +29,7 @@ object AnimesAriaFilters {
     class YearFilter : QueryPartFilter("Ano", AnimesAriaFiltersData.YEARS)
     class SeasonFilter : QueryPartFilter("Temporada", AnimesAriaFiltersData.SEASONS)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         TypeFilter(),
         GenreFilter(),
         StatusFilter(),

--- a/src/pt/animestc/build.gradle
+++ b/src/pt/animestc/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimesTC'
     pkgNameSuffix = 'pt.animestc'
     extClass = '.AnimesTC'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animestc/src/eu/kanade/tachiyomi/animeextension/pt/animestc/ATCFilters.kt
+++ b/src/pt/animestc/src/eu/kanade/tachiyomi/animeextension/pt/animestc/ATCFilters.kt
@@ -44,7 +44,7 @@ object ATCFilters {
         ATCFiltersData.GENRES.map { TriStateVal(it) },
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         InitialLetterFilter(),
         StatusFilter(),
         SortFilter(),

--- a/src/pt/animeszone/build.gradle
+++ b/src/pt/animeszone/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'AnimesZone'
     pkgNameSuffix = 'pt.animeszone'
     extClass = '.AnimesZone'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/pt/animeszone/src/eu/kanade/tachiyomi/animeextension/pt/animeszone/AnimesZoneFilters.kt
+++ b/src/pt/animeszone/src/eu/kanade/tachiyomi/animeextension/pt/animeszone/AnimesZoneFilters.kt
@@ -70,7 +70,7 @@ object AnimesZoneFilters {
 
     class AdultFilter : QueryPartFilter("Adulto", AnimesZoneFiltersData.ADULT)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         GenreFilter(),
         StudioFilter(),
         YearFilter(),

--- a/src/pt/anitube/build.gradle
+++ b/src/pt/anitube/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Anitube'
     pkgNameSuffix = 'pt.anitube'
     extClass = '.Anitube'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '13'
 }
 

--- a/src/pt/anitube/src/eu/kanade/tachiyomi/animeextension/pt/anitube/AnitubeFilters.kt
+++ b/src/pt/anitube/src/eu/kanade/tachiyomi/animeextension/pt/anitube/AnitubeFilters.kt
@@ -26,7 +26,7 @@ object AnitubeFilters {
     class YearFilter : QueryPartFilter("Ano", AnitubeFiltersData.YEARS)
     class SeasonFilter : QueryPartFilter("Temporada", AnitubeFiltersData.SEASONS)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         AnimeFilter.Header(AnitubeFiltersData.IGNORE_SEARCH_MSG),
         GenreFilter(),
         CharacterFilter(),

--- a/src/pt/betteranime/build.gradle
+++ b/src/pt/betteranime/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Better Anime'
     pkgNameSuffix = 'pt.betteranime'
     extClass = '.BetterAnime'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '13'
 }
 

--- a/src/pt/betteranime/src/eu/kanade/tachiyomi/animeextension/pt/betteranime/BAFilters.kt
+++ b/src/pt/betteranime/src/eu/kanade/tachiyomi/animeextension/pt/betteranime/BAFilters.kt
@@ -37,7 +37,7 @@ object BAFilters {
         BAFiltersData.GENRES.map { CheckBoxVal(it.first, false) },
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         LanguageFilter(),
         YearFilter(),
         GenresFilter(),

--- a/src/pt/megaflix/build.gradle
+++ b/src/pt/megaflix/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Megaflix'
     pkgNameSuffix = 'pt.megaflix'
     extClass = '.Megaflix'
-    extVersionCode = 4
+    extVersionCode = 5
     containsNsfw = true
 }
 

--- a/src/pt/megaflix/src/eu/kanade/tachiyomi/animeextension/pt/megaflix/MegaflixFilters.kt
+++ b/src/pt/megaflix/src/eu/kanade/tachiyomi/animeextension/pt/megaflix/MegaflixFilters.kt
@@ -23,7 +23,7 @@ object MegaflixFilters {
 
     class GenreFilter : QueryPartFilter("Gênero", MegaflixFiltersData.GENRES)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         AnimeFilter.Header(MegaflixFiltersData.IGNORE_SEARCH_MSG),
         GenreFilter(),
     )

--- a/src/pt/meusanimes/build.gradle
+++ b/src/pt/meusanimes/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Meus Animes'
     pkgNameSuffix = 'pt.meusanimes'
     extClass = '.MeusAnimes'
-    extVersionCode = 1
+    extVersionCode = 2
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/meusanimes/src/eu/kanade/tachiyomi/animeextension/pt/meusanimes/MAFilters.kt
+++ b/src/pt/meusanimes/src/eu/kanade/tachiyomi/animeextension/pt/meusanimes/MAFilters.kt
@@ -26,7 +26,7 @@ object MAFilters {
     class AudioFilter : QueryPartFilter("Áudio", MAFiltersData.AUDIO)
     class GenreFilter : QueryPartFilter("Gênero", MAFiltersData.GENRES)
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         AnimeFilter.Header(MAFiltersData.IGNORE_SEARCH_MSG),
         LetterFilter(),
         AnimeFilter.Header(MAFiltersData.IGNORE_LETTER_MSG),

--- a/src/pt/vizer/build.gradle
+++ b/src/pt/vizer/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Vizer.tv'
     pkgNameSuffix = 'pt.vizer'
     extClass = '.Vizer'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '13'
     containsNsfw = true
 }

--- a/src/pt/vizer/src/eu/kanade/tachiyomi/animeextension/pt/vizer/VizerFilters.kt
+++ b/src/pt/vizer/src/eu/kanade/tachiyomi/animeextension/pt/vizer/VizerFilters.kt
@@ -37,7 +37,7 @@ object VizerFilters {
         Selection(0, false),
     )
 
-    val FILTER_LIST = AnimeFilterList(
+    val FILTER_LIST get() = AnimeFilterList(
         TypeFilter(),
         MinYearFilter(),
         MaxYearFilter(),


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio (Not all of them)

And god said: `ag "FILTER_LIST = " -l | parallel 'sed -i "s/FILTER_LIST = AnimeFilterList(/FILTER_LIST get() = AnimeFilterList(/g"'`

Note: this PR does not fix the problem on DooPlay extensions, idk why