### PR TITLE
fix(en/9anime): Switch from Consumet's 9anime API

### DIFF
--- a/src/en/fmovies/build.gradle
+++ b/src/en/fmovies/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'FMovies'
     pkgNameSuffix = 'en.fmovies'
     extClass = '.FMovies'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '13'
 }
 

--- a/src/en/fmovies/src/eu/kanade/tachiyomi/animeextension/en/fmovies/FMovies.kt
+++ b/src/en/fmovies/src/eu/kanade/tachiyomi/animeextension/en/fmovies/FMovies.kt
@@ -249,10 +249,11 @@ class FMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                             )
                             val vidId = decrypted.substringAfterLast("/").substringBefore("?")
                             val (serverName, action) = when (name) {
-                                "Vidstream" -> Pair("Vidstream", "vizcloud")
-                                "MyCloud" -> Pair("MyCloud", "mcloud")
+                                "Vidstream" -> Pair("Vidstream", "rawVizcloud")
+                                "MyCloud" -> Pair("MyCloud", "rawMcloud")
                                 else -> return@parallelMap null
                             }
+
                             val playlistUrl = callConsumet(vidId, action)
                             val playlist = client.newCall(GET(playlistUrl, embedReferer)).execute()
 
@@ -289,11 +290,19 @@ class FMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     private fun callConsumet(query: String, action: String): String {
         return client.newCall(
-            GET("https://api.consumet.org/anime/9anime/helper?query=$query&action=$action"),
+            GET("https://9anime.eltik.net/$action?query=$query&apikey=aniyomi"),
         ).execute().body.string().let {
             when (action) {
-                "vizcloud", "mcloud" -> {
-                    it.substringAfter("file\":\"").substringBefore("\"")
+                "rawVizcloud", "rawMcloud" -> {
+                    val rawURL = json.decodeFromString<RawResponse>(it).rawURL
+                    val referer = if (action == "rawVizcloud") "https://vidstream.pro/" else "https://mcloud.to/"
+                    val apiResponse = client.newCall(
+                        GET(
+                            url = rawURL,
+                            headers = Headers.headersOf("Referer", referer),
+                        ),
+                    ).execute().body.string()
+                    apiResponse.substringAfter("file\":\"").substringBefore("\"")
                 }
                 "fmovies-decrypt" -> {
                     json.decodeFromString<VrfResponse>(it).url
@@ -411,7 +420,6 @@ class FMovies : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         private const val PREF_HOSTER_TITLE = "Enable/Disable Hosts"
         private val PREF_HOSTER_DEFAULT = setOf("Vidstream", "Filemoon")
     }
-
     // ============================== Settings ==============================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {

--- a/src/en/fmovies/src/eu/kanade/tachiyomi/animeextension/en/fmovies/FMoviesDto.kt
+++ b/src/en/fmovies/src/eu/kanade/tachiyomi/animeextension/en/fmovies/FMoviesDto.kt
@@ -34,3 +34,8 @@ data class FMoviesSubs(
     val file: String,
     val label: String,
 )
+
+@Serializable
+data class RawResponse(
+    val rawURL: String,
+)

--- a/src/en/nineanime/build.gradle
+++ b/src/en/nineanime/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = '9anime'
     pkgNameSuffix = 'en.nineanime'
     extClass = '.NineAnime'
-    extVersionCode = 43
+    extVersionCode = 44
     libVersion = '13'
 }
 


### PR DESCRIPTION
Consumet will be shutting down in a few months, so this is necessary to make sure the extension keeps working. Fixes [#1618](https://github.com/jmir1/aniyomi-extensions/issues/1618)

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
